### PR TITLE
Fixed the identifiers for Signed recipes

### DIFF
--- a/AdoptOpenJDK/AdoptOpenJDK11_OpenJ9_Signed.download.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK11_OpenJ9_Signed.download.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 11 Open J9. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 11 Open J9. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK11_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK11_OpenJ9_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/AdoptOpenJDK/AdoptOpenJDK11_OpenJ9_Signed.munki.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK11_OpenJ9_Signed.munki.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 11 Open J9. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 11 Open J9. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.munki.AdoptOpenJDK11_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.munki.AdoptOpenJDK11_OpenJ9_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK11_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK11_OpenJ9_Signed</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AdoptOpenJDK/AdoptOpenJDK11_Signed.download.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK11_Signed.download.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 11 HotSpot. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 11 HotSpot. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK11_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK11_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/AdoptOpenJDK/AdoptOpenJDK11_Signed.munki.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK11_Signed.munki.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 11 HotSpot. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 11 HotSpot. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.munki.AdoptOpenJDK11_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.munki.AdoptOpenJDK11_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK11_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK11_Signed</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AdoptOpenJDK/AdoptOpenJDK12_OpenJ9_Signed.download.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK12_OpenJ9_Signed.download.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 12 OpenJ9. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 12 OpenJ9. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK12_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK12_OpenJ9_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/AdoptOpenJDK/AdoptOpenJDK12_OpenJ9_Signed.munki.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK12_OpenJ9_Signed.munki.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 12 OpenJ9. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 12 OpenJ9. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.munki.AdoptOpenJDK12_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.munki.AdoptOpenJDK12_OpenJ9_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK12_OpenJ9_Signed</string>
+	<string>ccom.github.autopkg.grahampugh-recipes.AdoptOpenJDK12_OpenJ9_Signed</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AdoptOpenJDK/AdoptOpenJDK12_Signed.download.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK12_Signed.download.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 12 HotSpot. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 12 HotSpot. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK12_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK12_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/AdoptOpenJDK/AdoptOpenJDK12_Signed.munki.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK12_Signed.munki.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 12 HotSpot. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 12 HotSpot. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.munki.AdoptOpenJDK12_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.munki.AdoptOpenJDK12_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK12_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK12_Signed</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AdoptOpenJDK/AdoptOpenJDK8_OpenJ9_Signed.download.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK8_OpenJ9_Signed.download.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 8 OpenJ9. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 8 OpenJ9. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK8_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK8_OpenJ9_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/AdoptOpenJDK/AdoptOpenJDK8_OpenJ9_Signed.munki.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK8_OpenJ9_Signed.munki.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 8 OpenJ9. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 8 OpenJ9. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.munki.AdoptOpenJDK8_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.munki.AdoptOpenJDK8_OpenJ9_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK8_OpenJ9_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK8_OpenJ9_Signed</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AdoptOpenJDK/AdoptOpenJDK8_Signed.download.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK8_Signed.download.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 8 HotSpot. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 8 HotSpot. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK8_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK8_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/AdoptOpenJDK/AdoptOpenJDK8_Signed.munki.recipe
+++ b/AdoptOpenJDK/AdoptOpenJDK8_Signed.munki.recipe
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of AdoptOpenJDK 8 HotSpot. Recipe created by Charles Mission.</string>
+	<string>Downloads the current release version of AdoptOpenJDK 8 HotSpot. Recipe created by Charles Misson.</string>
 	<key>Identifier</key>
-	<string>com.github.grahampugh.recipes.munki.AdoptOpenJDK8_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.munki.AdoptOpenJDK8_Signed</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.grahampugh.recipes.download.AdoptOpenJDK8_Signed</string>
+	<string>com.github.autopkg.grahampugh-recipes.download.AdoptOpenJDK8_Signed</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Hi @grahampugh 

Yesterday when I tested the updated Signed recipes, they were all in the same folder on my computer (the .download and .munki) so they ran fine. 
But when I tried to make an override to use them with my company's internal autopkg, they all failed. 

The beginning of the identifier was set to `com.github.grahampugh.recipes.` which tells autopkg to look for the recipe in your own repo,(https://github.com/grahampugh/recipes/tree/master/AdoptOpenJDK), but these Signed recipes only exists in the repo called `autopkg/grahampugh-recipes` and this is why autopkg is failing to find the parent recipe.
For the signed recipes, the identifier should start with `com.github.autopkg.grahampugh-recipes.` so autopkg will know where to look.

I also fixed a typo in my family name, there was an extra `i`.

Thanks,
Charles