### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/DataWarrior/DataWarrior.download.recipe
+++ b/DataWarrior/DataWarrior.download.recipe
@@ -58,9 +58,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/DataWarrior.app</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/DataWarrior.app</string>
                 <key>overwrite</key>
 				<true/>
 			</dict>
@@ -71,9 +71,9 @@
             <key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/DataWarrior.app/Contents/Info.plist</string>
                 <key>output_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/DataWarrior.app/Contents/Info.plist</string>
                 <key>plist_data</key>
                 <dict>
                      <key>CFBundleShortVersionString</key>

--- a/DataWarrior/DataWarrior.pkg.recipe
+++ b/DataWarrior/DataWarrior.pkg.recipe
@@ -29,7 +29,7 @@
 				<key>version</key>
 				<string>%webversion%</string>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/DataWarrior.app</string>
                 <key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
                 <key>overwrite</key>

--- a/GIMP/GIMP.pkg.recipe
+++ b/GIMP/GIMP.pkg.recipe
@@ -48,7 +48,7 @@
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/GIMP.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -57,7 +57,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>gimp_app_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/GIMP.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/ISLLightClient/ISLLightClient.pkg.recipe
+++ b/ISLLightClient/ISLLightClient.pkg.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/ISL Light Client.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -74,7 +74,7 @@
 				<key>archive_path</key>
 				<string>%RECIPE_CACHE_DIR%/tarball.tar.bz2</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/LibreOffice.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>

--- a/LineIn/LineIn.download.recipe
+++ b/LineIn/LineIn.download.recipe
@@ -64,7 +64,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/LineIn.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.rogueamoeba.LineIn2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7266XEXAPM")</string>
 			</dict>
@@ -75,7 +75,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/LineIn.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/LineIn/LineIn.install.recipe
+++ b/LineIn/LineIn.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>LineIn.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/eqMac/eqMac.download.recipe
+++ b/eqMac/eqMac.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/eqMac.app</string>
 				<key>requirement</key>
 				<string/>
 			</dict>
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/eqMac.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/eqMac/eqMac.install.recipe
+++ b/eqMac/eqMac.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>eqMac.app</string>
 					</dict>
 				</array>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.