### PR TITLE
Basic python3 compatibility

### DIFF
--- a/AppleJava6/Java6Versioner.py
+++ b/AppleJava6/Java6Versioner.py
@@ -16,8 +16,9 @@
 """See docstring for Java6Versioner class"""
 
 from __future__ import absolute_import
-import subprocess
+
 import plistlib
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["Java6Versioner"]

--- a/AppleJava6/Java6Versioner.py
+++ b/AppleJava6/Java6Versioner.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for Java6Versioner class"""
 
+from __future__ import absolute_import
 import subprocess
 import plistlib
 from autopkglib import Processor, ProcessorError

--- a/CommonProcessors/ChangeModeOwner.py
+++ b/CommonProcessors/ChangeModeOwner.py
@@ -4,6 +4,7 @@
 Adapted from com.github.jessepeterson.munki.PortfolioClient10/ModeChanger.py.
 """
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import subprocess
 import os

--- a/CommonProcessors/ChangeModeOwner.py
+++ b/CommonProcessors/ChangeModeOwner.py
@@ -5,9 +5,10 @@ Adapted from com.github.jessepeterson.munki.PortfolioClient10/ModeChanger.py.
 """
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import subprocess
-import os
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["ChangeModeOwner"]
 

--- a/CommonProcessors/ChoicesXMLGenerator.py
+++ b/CommonProcessors/ChoicesXMLGenerator.py
@@ -16,6 +16,7 @@
 """See docstring for SubDirectoryList class"""
 
 
+from __future__ import absolute_import
 import os, sys
 import subprocess
 from autopkglib import Processor, ProcessorError

--- a/CommonProcessors/ChoicesXMLGenerator.py
+++ b/CommonProcessors/ChoicesXMLGenerator.py
@@ -17,8 +17,9 @@
 
 
 from __future__ import absolute_import
-import os, sys
+
 import subprocess
+
 from autopkglib import Processor, ProcessorError
 from FoundationPlist import readPlistFromString, writePlist
 

--- a/CommonProcessors/SubDirectoryList.py
+++ b/CommonProcessors/SubDirectoryList.py
@@ -131,7 +131,7 @@ class SubDirectoryList(Processor):
                 if relpath == ".":
                     # we want to avoid prepending './' to files at root dir
                     relpath = ''
-                # print "Real relative path: %s" % relpath
+                # print("Real relative path: %s" % relpath)
                 file_list.append(os.path.join(relpath, fname))
         self.env['found_directories'] = search_string.format(format_string.join(dir_list)).strip()
         self.env['found_filenames'] = search_string.format(format_string.join(file_list)).strip()

--- a/CommonProcessors/SubDirectoryList.py
+++ b/CommonProcessors/SubDirectoryList.py
@@ -17,7 +17,9 @@
 
 
 from __future__ import absolute_import
+
 import os
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["SubDirectoryList"]

--- a/CommonProcessors/SubDirectoryList.py
+++ b/CommonProcessors/SubDirectoryList.py
@@ -16,6 +16,7 @@
 """See docstring for SubDirectoryList class"""
 
 
+from __future__ import absolute_import
 import os
 from autopkglib import Processor, ProcessorError
 

--- a/FileMaker/FilemakerProAdvancedUpdateExtractor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateExtractor.py
@@ -70,7 +70,7 @@ class FilemakerProAdvancedUpdateExtractor(DmgMounter):
                     pkgs = [f for f in contents if fnmatch.fnmatch(f, '*.pkg')]
                     zf.extract(pkgs[0], self.env["RECIPE_CACHE_DIR"])
                     self.env["pkg_path"] = os.path.join(self.env["RECIPE_CACHE_DIR"], os.path.basename(pkgs[0]))
-            except BaseException as err:
+            except Exception as err:
                 raise ProcessorError(err)
         else:
             mount_point = self.mount(self.env["downloaded_file"])
@@ -80,7 +80,7 @@ class FilemakerProAdvancedUpdateExtractor(DmgMounter):
                 pkg = self.find_pkg(mount_point)
                 shutil.copy(pkg, self.env['RECIPE_CACHE_DIR'])
                 self.env["pkg_path"] = os.path.join(self.env['RECIPE_CACHE_DIR'], os.path.basename(pkg))
-            except BaseException as err:
+            except Exception as err:
                 raise ProcessorError(err)
             finally:
                 self.unmount(self.env["downloaded_file"])

--- a/FileMaker/FilemakerProAdvancedUpdateExtractor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateExtractor.py
@@ -21,13 +21,14 @@
 """See docstring for FilemakerProAdvancedUpdateDMGExtractor class"""
 
 from __future__ import absolute_import
-import json
+
+import fnmatch
 import os
 import shutil
 import zipfile
-import fnmatch
-from autopkglib.DmgMounter import DmgMounter
+
 from autopkglib import Processor, ProcessorError
+from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["FilemakerProAdvancedUpdateExtractor"]
 

--- a/FileMaker/FilemakerProAdvancedUpdateExtractor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateExtractor.py
@@ -20,6 +20,7 @@
 
 """See docstring for FilemakerProAdvancedUpdateDMGExtractor class"""
 
+from __future__ import absolute_import
 import json
 import os
 import shutil
@@ -68,7 +69,7 @@ class FilemakerProAdvancedUpdateExtractor(DmgMounter):
                     pkgs = [f for f in contents if fnmatch.fnmatch(f, '*.pkg')]
                     zf.extract(pkgs[0], self.env["RECIPE_CACHE_DIR"])
                     self.env["pkg_path"] = os.path.join(self.env["RECIPE_CACHE_DIR"], os.path.basename(pkgs[0]))
-            except BaseException, err:
+            except BaseException as err:
                 raise ProcessorError(err)
         else:
             mount_point = self.mount(self.env["downloaded_file"])
@@ -78,7 +79,7 @@ class FilemakerProAdvancedUpdateExtractor(DmgMounter):
                 pkg = self.find_pkg(mount_point)
                 shutil.copy(pkg, self.env['RECIPE_CACHE_DIR'])
                 self.env["pkg_path"] = os.path.join(self.env['RECIPE_CACHE_DIR'], os.path.basename(pkg))
-            except BaseException, err:
+            except BaseException as err:
                 raise ProcessorError(err)
             finally:
                 self.unmount(self.env["downloaded_file"])

--- a/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
@@ -164,7 +164,7 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
         return update
 
     def version_matcher(self, url):
-       	fname = os.path.basename(urlparse.urlsplit(url).path)
+        fname = os.path.basename(urlparse.urlsplit(url).path)
         version_match = re.search(r"([0-9]{2}.[0-9]{0,2}.[0-9]{0,2})", fname)
         if version_match == None:
             raise ProcessorError("Something went wrong matching FMP update to full version.")

--- a/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
@@ -153,7 +153,7 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
             f = urllib2.urlopen(req)
             data = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't get to Filemaker Updater feed: %s" % e)
 
         metadata = json.loads(data)
@@ -187,7 +187,7 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
             self.env["url"] = url
             self.env["package_name"] = update["name"]
             self.env["package_file"] = os.path.basename(urlparse.urlsplit(url).path)
-        except BaseException as err:
+        except Exception as err:
             # handle unexpected errors here
             raise ProcessorError(err)
 

--- a/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
@@ -19,6 +19,7 @@
 
 """See docstring for FilemakerProAdvancedUpdateURLProcessor class"""
 
+from __future__ import absolute_import
 import json
 import re
 import os

--- a/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
@@ -20,12 +20,14 @@
 """See docstring for FilemakerProAdvancedUpdateURLProcessor class"""
 
 from __future__ import absolute_import
+
 import json
-import re
 import os
+import re
 import urllib2
-from urllib2 import urlparse
 from operator import itemgetter
+from urllib2 import urlparse
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["FilemakerProAdvancedUpdateURLProcessor"]

--- a/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
@@ -92,7 +92,7 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
     def extractAdvancedUpdates(self, obj):
         updates = []
         for pkg in obj:
-            if re.search('Advanced', pkg["product"]):
+            if re.search(r'Advanced', pkg["product"]):
                 updates.append(pkg)
         return updates
 
@@ -128,14 +128,14 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
             if len(version) > 3:
                 build = version[3]
             # look for a letter in the patchlevel
-            mo = re.search('([0-9]*)([A-Za-z]*)', patch)
+            mo = re.search(r'([0-9]*)([A-Za-z]*)', patch)
             if mo != None:
                 (patch, build) = mo.groups()
                 if build == '':
                     build = 0
                 else:
                     build = patch_levels[build]
-            mo = re.search('([0-9]*)v([0-9]*)', minor)
+            mo = re.search(r'([0-9]*)v([0-9]*)', minor)
             if mo != None:
                 (minor, build) = mo.groups()
             versions.append((major, minor, patch, version_str))

--- a/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
@@ -129,14 +129,14 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
                 build = version[3]
             # look for a letter in the patchlevel
             mo = re.search(r'([0-9]*)([A-Za-z]*)', patch)
-            if mo != None:
+            if mo is not None:
                 (patch, build) = mo.groups()
                 if build == '':
                     build = 0
                 else:
                     build = patch_levels[build]
             mo = re.search(r'([0-9]*)v([0-9]*)', minor)
-            if mo != None:
+            if mo is not None:
                 (minor, build) = mo.groups()
             versions.append((major, minor, patch, version_str))
         sorted_versions = sorted(versions, key=itemgetter(0,1,2,3), reverse=True)
@@ -169,7 +169,7 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
     def version_matcher(self, url):
         fname = os.path.basename(urlparse.urlsplit(url).path)
         version_match = re.search(r"([0-9]{2}.[0-9]{0,2}.[0-9]{0,2})", fname)
-        if version_match == None:
+        if version_match is None:
             raise ProcessorError("Something went wrong matching FMP update to full version.")
         else:
             return version_match.group(1)

--- a/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
+++ b/FileMaker/FilemakerProAdvancedUpdateURLProcessor.py
@@ -36,9 +36,6 @@ UPDATE_FEED = "https://www.filemaker.com/support/updaters/product-updaters.txt"
 
 class FilemakerProAdvancedUpdateURLProcessor(Processor):
     """Provides a download URL for the most recent version of FileMaker Pro Advanced"""
-    # an enum-like hash to enable the variant of FileMaker versioning to be taken
-    # into account when versioning
-    patch_levels = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
 
     description = __doc__
     input_variables = {
@@ -111,6 +108,10 @@ class FilemakerProAdvancedUpdateURLProcessor(Processor):
         return v1
 
     def findLatestUpdate(self, obj):
+        # an enum-like hash to enable the variant of FileMaker versioning to be taken
+        # into account when versioning
+        patch_levels = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+
         updates = []
         versions = []
         for pkg in obj:

--- a/Parallels/ParallelsDesktopPackager.py
+++ b/Parallels/ParallelsDesktopPackager.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 import subprocess

--- a/Parallels/ParallelsDesktopPackager.py
+++ b/Parallels/ParallelsDesktopPackager.py
@@ -15,11 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
-import subprocess
-import os.path
 import plistlib
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["ParallelsDesktopPackager"]
 

--- a/PostProcessors/slacker.py
+++ b/PostProcessors/slacker.py
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-from autopkglib import Processor, ProcessorError
+from __future__ import absolute_import, print_function
 
-import subprocess
-import os.path
-import json
 import requests
+
+from autopkglib import Processor, ProcessorError
 
 # Set the webhook_url to the one provided by Slack when you create the webhook at https://my.slack.com/services/new/incoming-webhook/
 

--- a/PostProcessors/slacker.py
+++ b/PostProcessors/slacker.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor, ProcessorError
 
 import subprocess
@@ -78,13 +80,13 @@ class Slacker(Processor):
             jss_policy_name = "%s" % jss_importer_summary_result["data"]["Policy"]
             jss_policy_version = "%s" % jss_importer_summary_result["data"]["Version"]
             jss_uploaded_package = "%s" % jss_importer_summary_result["data"]["Package"]
-            print "JSS address: %s" % JSS_URL
-            print "Title: %s" % prod_name
-            print "Policy: %s" % jss_policy_name
-            print "Version: %s" % jss_policy_version
-            print "Category: %s" % category
-            print "Policy Category: %s" % policy_category
-            print "Package: %s" % jss_uploaded_package
+            print("JSS address: %s" % JSS_URL)
+            print("Title: %s" % prod_name)
+            print("Policy: %s" % jss_policy_name)
+            print("Version: %s" % jss_policy_version)
+            print("Category: %s" % category)
+            print("Policy Category: %s" % policy_category)
+            print("Package: %s" % jss_uploaded_package)
             if jss_uploaded_package:
                 slack_text = "*New Item added to JSS:*\nURL: %s\nTitle: *%s*\nVersion: *%s*\nCategory: *%s*\nPolicy Name: *%s*\nUploaded Package Name: *%s*" % (JSS_URL, prod_name, jss_policy_version, category, jss_policy_name, jss_uploaded_package)
             else:


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib2.urlopen()` and `urllib2.urlparse()`), but this should catch the low-hanging fruit right now.