### PR TITLE
New SEARCH_URL

### DIFF
--- a/AmazonCorrettoJDK/AmazonCorrettoJDK8.pkg.recipe
+++ b/AmazonCorrettoJDK/AmazonCorrettoJDK8.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;https://.*?amazon-corretto-8.*?-macosx-x64\.tar\.gz)</string>
 		<key>SEARCH_URL</key>
-		<string>https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html</string>
+		<string>https://github.com/corretto/corretto-8/releases/latest</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
Replaced the Search url to https://github.com/corretto/corretto-8/releases/latest as the previous url no longer works.