### PR TITLE
Update FoldingAtHome.download.recipe

### DIFF
--- a/FoldingAtHome/FoldingAtHome.download.recipe
+++ b/FoldingAtHome/FoldingAtHome.download.recipe
@@ -21,7 +21,7 @@
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;https:\/\/download\.foldingathome\.org\/releases\/public\/release\/fah-installer\/osx-10.*fah-installer_(?P&lt;version&gt;.*?)_x86_64\.mpkg\.zip)</string>
 				<key>url</key>
-				<string>https://download.foldingathome.org</string>
+				<string>https://download.foldingathome.org/js/fah-downloads.js</string>
 				<key>user-agent</key>
 				<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15</string>
 			</dict>


### PR DESCRIPTION
Found a download URL that references the latest version. https://download.foldingathome.org/js/fah-downloads.js