### PR TITLE
Update AmazonCorrettoJDK8.pkg.recipe

### DIFF
--- a/AmazonCorrettoJDK/AmazonCorrettoJDK8.pkg.recipe
+++ b/AmazonCorrettoJDK/AmazonCorrettoJDK8.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;https://.*?amazon-corretto-8.*?-macosx-x64\.tar\.gz)</string>
 		<key>SEARCH_URL</key>
-		<string>https://github.com/corretto/corretto-8/releases/latest</string>
+		<string>https://github.com/corretto/corretto-8/releases</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
Latest release doesn't have macOS versions, using https://github.com/corretto/corretto-8/releases seems to pull the previous-latest which does.