### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/GIMP/GIMP.pkg.recipe
+++ b/GIMP/GIMP.pkg.recipe
@@ -65,10 +65,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -101,9 +101,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%_%LANGUAGE_CODE%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%_%LANGUAGE_CODE%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/LogitechPresentation/LogitechPresentation.pkg.recipe
+++ b/LogitechPresentation/LogitechPresentation.pkg.recipe
@@ -172,9 +172,9 @@ DIR=$(dirname "$0")
 					<string>flat</string>
 					<key>scripts</key>
 					<string>Scripts</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/MestReNova/MestReNova.pkg.recipe
+++ b/MestReNova/MestReNova.pkg.recipe
@@ -66,9 +66,9 @@
 					<string>flat</string>
 					<key>version</key>
 					<string>%pkgversion%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).