### PR TITLE
Remove unnecessary user-agent from URLTextSearcher

### DIFF
--- a/FoldingAtHome/FoldingAtHome.download.recipe
+++ b/FoldingAtHome/FoldingAtHome.download.recipe
@@ -22,8 +22,6 @@
 				<string>(?P&lt;url&gt;https:\/\/download\.foldingathome\.org\/releases\/public\/release\/fah-installer\/osx-10.*fah-installer_(?P&lt;version&gt;.*?)_x86_64\.mpkg\.zip)</string>
 				<key>url</key>
 				<string>https://download.foldingathome.org/releases.py?series=7.6&amp;release=public</string>
-				<key>user-agent</key>
-				<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/LogitechPresentation/LogitechPresentation.download.recipe
+++ b/LogitechPresentation/LogitechPresentation.download.recipe
@@ -24,8 +24,6 @@
 				<string>(?P&lt;url&gt;https:\/\/download01\.logi\.com\/web\/ftp\/pub\/techsupport\/presentation\/LogiPresentation_(?P&lt;version&gt;.*?)\.dmg)</string>
 				<key>url</key>
 				<string>https://www.logitech.com/en-gb/product/spotlight-presentation-remote/page/spotlight-features</string>
-				<key>user-agent</key>
-				<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/SeqMonk/SeqMonk.download.recipe
+++ b/SeqMonk/SeqMonk.download.recipe
@@ -22,8 +22,6 @@
 				<string>(?P&lt;match&gt;seqmonk/seqmonk_v(?P&lt;version&gt;.*?)_osx64\.dmg)</string>
 				<key>url</key>
 				<string>https://www.bioinformatics.babraham.ac.uk/projects/download.html</string>
-				<key>user-agent</key>
-				<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
These recipes all seem to work without the use of a hard-coded user-agent.

If a user-agent is desired, it should be contained in the `request_headers` dictionary, as in this example:

```
<dict>
	<key>Arguments</key>
	<dict>
		<key>re_pattern</key>
		<string>(?P&lt;url&gt;https:\/\/download\.foldingathome\.org\/releases\/public\/release\/fah-installer\/osx-10.*fah-installer_(?P&lt;version&gt;.*?)_x86_64\.mpkg\.zip)</string>
		<key>request_headers</key>
		<dict>
			<key>user-agent</key>
			<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15</string>
		</dict>
		<key>url</key>
		<string>https://download.foldingathome.org/releases.py?series=7.6&amp;release=public</string>
	</dict>
	<key>Processor</key>
	<string>URLTextSearcher</string>
</dict>
```