### PR TITLE
Added support for the HTTP/2 response header

### DIFF
--- a/JamfUploaderProcessors/JamfCategoryUploader.py
+++ b/JamfUploaderProcessors/JamfCategoryUploader.py
@@ -177,7 +177,7 @@ class JamfCategoryUploader(Processor):
                 headers = file.readlines()
             r.headers = [x.strip() for x in headers]
             for header in r.headers:
-                if "HTTP/1.1" in header and "Continue" not in header:
+                if ("HTTP/1.1" in header or "HTTP/2" in header) and "Continue" not in header:
                     r.status_code = int(header.split()[1])
             with open(output_file, "rb") as file:
                 if "uapi" in url:

--- a/JamfUploaderProcessors/JamfComputerGroupUploader.py
+++ b/JamfUploaderProcessors/JamfComputerGroupUploader.py
@@ -180,7 +180,7 @@ class JamfComputerGroupUploader(Processor):
                 headers = file.readlines()
             r.headers = [x.strip() for x in headers]
             for header in r.headers:
-                if "HTTP/1.1" in header and "Continue" not in header:
+                if ("HTTP/1.1" in header or "HTTP/2" in header) and "Continue" not in header:
                     r.status_code = int(header.split()[1])
             with open(output_file, "rb") as file:
                 if "uapi" in url:

--- a/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
@@ -182,7 +182,7 @@ class JamfExtensionAttributeUploader(Processor):
                 headers = file.readlines()
             r.headers = [x.strip() for x in headers]
             for header in r.headers:
-                if "HTTP/1.1" in header and "Continue" not in header:
+                if ("HTTP/1.1" in header or "HTTP/2" in header) and "Continue" not in header:
                     r.status_code = int(header.split()[1])
             with open(output_file, "rb") as file:
                 if "uapi" in url:

--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -280,7 +280,7 @@ class JamfPackageUploader(Processor):
                 headers = file.readlines()
             r.headers = [x.strip() for x in headers]
             for header in r.headers:
-                if "HTTP/1.1" in header and "Continue" not in header:
+                if ("HTTP/1.1" in header or "HTTP/2" in header) and "Continue" not in header:
                     r.status_code = int(header.split(" ")[1])
             with open(output_file, "rb") as file:
                 if "uapi" in url:

--- a/JamfUploaderProcessors/JamfPolicyDeleter.py
+++ b/JamfUploaderProcessors/JamfPolicyDeleter.py
@@ -154,7 +154,7 @@ class JamfPolicyDeleter(Processor):
                 headers = file.readlines()
             r.headers = [x.strip() for x in headers]
             for header in r.headers:
-                if "HTTP/1.1" in header and "Continue" not in header:
+                if ("HTTP/1.1" in header or "HTTP/2" in header) and "Continue" not in header:
                     r.status_code = int(header.split()[1])
             with open(output_file, "rb") as file:
                 if "uapi" in url:

--- a/JamfUploaderProcessors/JamfPolicyUploader.py
+++ b/JamfUploaderProcessors/JamfPolicyUploader.py
@@ -194,7 +194,7 @@ class JamfPolicyUploader(Processor):
                 headers = file.readlines()
             r.headers = [x.strip() for x in headers]
             for header in r.headers:
-                if "HTTP/1.1" in header and "Continue" not in header:
+                if ("HTTP/1.1" in header or "HTTP/2" in header) and "Continue" not in header:
                     r.status_code = int(header.split()[1])
             with open(output_file, "rb") as file:
                 if "uapi" in url:

--- a/JamfUploaderProcessors/JamfScriptUploader.py
+++ b/JamfUploaderProcessors/JamfScriptUploader.py
@@ -249,7 +249,7 @@ class JamfScriptUploader(Processor):
                 headers = file.readlines()
             r.headers = [x.strip() for x in headers]
             for header in r.headers:
-                if "HTTP/1.1" in header and "Continue" not in header:
+                if ("HTTP/1.1" in header or "HTTP/2" in header) and "Continue" not in header:
                     r.status_code = int(header.split()[1])
             with open(output_file, "rb") as file:
                 if "uapi" in url:


### PR DESCRIPTION
If Jamf Pro is behind a Reverse Proxy which uses HTTP/2, the original code does not recognize the header. This will fix it.