### PR TITLE
Remove unused BUNDLE_ID input var and fix FileZilla regex

### DIFF
--- a/CotEditor/CotEditor.pkg.recipe
+++ b/CotEditor/CotEditor.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.grahampugh.pkg.CotEditor</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.coteditor.CotEditor</string>
 		<key>NAME</key>
 		<string>CotEditor</string>
 	</dict>

--- a/DataWarrior/DataWarrior.pkg.recipe
+++ b/DataWarrior/DataWarrior.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.grahampugh.pkg.DataWarrior</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.openmolecules.datawarrior</string>
 		<key>DOWNLOAD_URL</key>
 		<string>http://www.openmolecules.org/datawarrior/download.html</string>
 		<key>NAME</key>

--- a/Element/Element.pkg.recipe
+++ b/Element/Element.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.grahampugh.recipes.pkg.Element</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>im.riot.app</string>
 		<key>NAME</key>
 		<string>Element</string>
 	</dict>

--- a/FileZilla/FileZilla-stable.download.recipe
+++ b/FileZilla/FileZilla-stable.download.recipe
@@ -32,9 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>"(?P&lt;url&gt;https://.*/client/FileZilla_.*_macosx-x86.*)"</string>
-				<key>result_output_var_name</key>
-				<string>url</string>
+				<string>"(?P&lt;url&gt;https://.*/client/FileZilla_.*_macosx-x86\S+)"</string>
 				<key>url</key>
 				<string>%SEARCH_URL%</string>
 			</dict>

--- a/FileZilla/FileZilla-stable.download.recipe
+++ b/FileZilla/FileZilla-stable.download.recipe
@@ -21,9 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>\&lt;\p\&gt;The latest stable version of FileZilla Client is (?P&lt;dl_version&gt;.*)\&lt;\/p\&gt;</string>
-				<key>result_output_var_name</key>
-				<string>dl_version</string>
+				<string>&lt;p&gt;The latest stable version of FileZilla Client is (?P&lt;dl_version&gt;.*)&lt;\/p&gt;</string>
 				<key>url</key>
 				<string>%SEARCH_URL%</string>
 			</dict>

--- a/FileZilla/FileZilla-stable.pkg.recipe
+++ b/FileZilla/FileZilla-stable.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.grahampugh.recipes.pkg.FileZilla</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.filezilla-project.filezilla.pkg</string>
 		<key>NAME</key>
 		<string>FileZilla</string>
 	</dict>

--- a/KNIME/KNIME.pkg.recipe
+++ b/KNIME/KNIME.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.grahampugh.recipes.pkg.KNIME</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.knime.product</string>
 		<key>NAME</key>
 		<string>KNIME</string>
 	</dict>

--- a/Riot/Riot.pkg.recipe
+++ b/Riot/Riot.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.grahampugh.recipes.pkg.Riot</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>im.riot.app</string>
 		<key>NAME</key>
 		<string>Riot</string>
 	</dict>

--- a/ThinLincClient/ThinLincClient.pkg.recipe
+++ b/ThinLincClient/ThinLincClient.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.grahampugh.recipes.pkg.ThinLincClient</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>se.cendio.tlclient</string>
 		<key>NAME</key>
 		<string>ThinLinc Client</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

This PR also includes a fix for some regular expression issues with the FileZilla recipes.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ CotEditor/CotEditor.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/CotEditor/CotEditor.pkg.recipe
Processing repos/grahampugh-recipes/CotEditor/CotEditor.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'coteditor/CotEditor'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'CotEditor_4.0.1.dmg' from release '4.0.1'
{'Output': {'release_notes': 'system requirements: __macOS 10.15__ and '
                             'later\r\n'
                             '\r\n'
                             '### Improvements\r\n'
                             '\r\n'
                             '- [trivial] Reset toolbar setting.\r\n'
                             '- [dev] Update Yams package to 4.0.1.\r\n'
                             '- [dev] Update the build environment to Xcode '
                             '12.2.\r\n'
                             '\r\n'
                             '\r\n'
                             '### Fixes\r\n'
                             '\r\n'
                             '- Fix an issue on the Big Sur that the '
                             'navigation bar in the document window '
                             'disappeared.',
            'url': 'https://github.com/coteditor/CotEditor/releases/download/4.0.1/CotEditor_4.0.1.dmg',
            'version': '4.0.1'}}
URLDownloader
{'Input': {'filename': 'CotEditor-4.0.1.dmg',
           'url': 'https://github.com/coteditor/CotEditor/releases/download/4.0.1/CotEditor_4.0.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/downloads/CotEditor-4.0.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/downloads/CotEditor-4.0.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/downloads/CotEditor-4.0.1.dmg/CotEditor.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.coteditor.CotEditor" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = HT3Z3A72WZ)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/downloads/CotEditor-4.0.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.sVFhru/CotEditor.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.sVFhru/CotEditor.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.sVFhru/CotEditor.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/downloads/CotEditor-4.0.1.dmg/CotEditor.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/downloads/CotEditor-4.0.1.dmg
Versioner: Found version 4.0.1 in file /private/tmp/dmg.0MALdc/CotEditor.app/Contents/Info.plist
{'Output': {'version': '4.0.1'}}
AppPkgCreator
{'Input': {'version': '4.0.1'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/downloads/CotEditor-4.0.1.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ZhwbLi/CotEditor.app' matched from globbed '/private/tmp/dmg.ZhwbLi/*.app'.
AppPkgCreator: BundleID: com.coteditor.CotEditor
AppPkgCreator: Copied /private/tmp/dmg.ZhwbLi/CotEditor.app to ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/payload/Applications/CotEditor.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.coteditor.CotEditor',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/CotEditor-4.0.1.pkg',
                                                        'version': '4.0.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.0.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/receipts/CotEditor.pkg-receipt-20210213-233315.plist

The following packages were built:
    Identifier               Version  Pkg Path                                                                                      
    ----------               -------  --------                                                                                      
    com.coteditor.CotEditor  4.0.1    ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.CotEditor/CotEditor-4.0.1.pkg  
```

## ✅ DataWarrior/DataWarrior.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/DataWarrior/DataWarrior.pkg.recipe
Processing repos/grahampugh-recipes/DataWarrior/DataWarrior.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(?P<match>http.*?dmg\\?dl=1)',
           'url': 'http://www.openmolecules.org/datawarrior/download.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://www.dropbox.com/s/q097qvjvbmh0c73/datawarrior.dmg?dl=1
{'Output': {'match': 'https://www.dropbox.com/s/q097qvjvbmh0c73/datawarrior.dmg?dl=1'}}
URLDownloader
{'Input': {'filename': 'DataWarrior.dmg',
           'url': 'https://www.dropbox.com/s/q097qvjvbmh0c73/datawarrior.dmg?dl=1'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': '(.*Download DataWarrior '
                         'V(?P<webversion>\\d\\.\\d+\\.\\d+).*)',
           'result_output_var_name': 'webversion',
           'url': 'http://www.openmolecules.org/datawarrior/download.html'}}
URLTextSearcher: Found matching text (webversion): 5.2.1
{'Output': {'webversion': '5.2.1'}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.dmg/DataWarrior.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.dmg, dmg: .dmg/, dmg_source_path: DataWarrior.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.dmg
Copier: Copied /private/tmp/dmg.zXFHVG/DataWarrior.app to ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.app
{'Output': {}}
PlistEditor
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist',
           'output_plist_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist',
           'plist_data': {'CFBundleShortVersionString': '5.2.1'}}}
PlistEditor: Updated plist at ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.app',
           'force_pkg_build': True,
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/DataWarrior-5.2.1.pkg',
           'version': '5.2.1'}}
AppPkgCreator: BundleID: org.openmolecules.datawarrior
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/downloads/DataWarrior.app to ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/payload/Applications/DataWarrior.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.openmolecules.datawarrior',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/DataWarrior-5.2.1.pkg',
                                                        'version': '5.2.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '5.2.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/receipts/DataWarrior.pkg-receipt-20210213-233342.plist

The following packages were built:
    Identifier                     Version  Pkg Path                                                                                          
    ----------                     -------  --------                                                                                          
    org.openmolecules.datawarrior  5.2.1    ~/Library/AutoPkg/Cache/com.github.grahampugh.pkg.DataWarrior/DataWarrior-5.2.1.pkg  
```

## ✅ Element/Element.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/Element/Element.pkg.recipe
Processing repos/grahampugh-recipes/Element/Element.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '"(?P<match>https://packages\\.riot\\.im/desktop/install/macos/Element.*\\.dmg)"',
           'url': 'https://element.io/get-started'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://packages.riot.im/desktop/install/macos/Element.dmg
{'Output': {'match': 'https://packages.riot.im/desktop/install/macos/Element.dmg'}}
URLDownloader
{'Input': {'filename': 'Element.dmg',
           'url': 'https://packages.riot.im/desktop/install/macos/Element.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/downloads/Element.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/downloads/Element.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/downloads/Element.dmg/Element.app',
           'requirement': 'identifier "im.riot.app" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7J4U792NQT"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/downloads/Element.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ynQh7R/Element.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ynQh7R/Element.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ynQh7R/Element.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/downloads/Element.dmg/Element.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/downloads/Element.dmg
Versioner: Found version 1.7.20 in file /private/tmp/dmg.GdyXqs/Element.app/Contents/Info.plist
{'Output': {'version': '1.7.20'}}
AppPkgCreator
{'Input': {'force_pkg_build': True,
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/Element-1.7.20.pkg',
           'version': '1.7.20'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/downloads/Element.dmg
AppPkgCreator: Using path '/private/tmp/dmg.vTKF1p/Element.app' matched from globbed '/private/tmp/dmg.vTKF1p/*.app'.
AppPkgCreator: BundleID: im.riot.app
AppPkgCreator: Copied /private/tmp/dmg.vTKF1p/Element.app to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/payload/Applications/Element.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'im.riot.app',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/Element-1.7.20.pkg',
                                                        'version': '1.7.20'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.7.20'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/receipts/Element.pkg-receipt-20210213-233414.plist

The following packages were built:
    Identifier   Version  Pkg Path                                                                                           
    ----------   -------  --------                                                                                           
    im.riot.app  1.7.20   ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Element/Element-1.7.20.pkg  
```

## ✅ FileZilla/FileZilla-stable.download.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/FileZilla/FileZilla-stable.download.recipe
Processing ~/Developer/_personal/sheepdog/repos/grahampugh-recipes/FileZilla/FileZilla-stable.download.recipe...
URLTextSearcher
{'Input': {'re_pattern': '<p>The latest stable version of FileZilla Client is '
                         '(?P<dl_version>.*)<\\/p>',
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (dl_version): 3.52.2
URLTextSearcher: Found matching text (match): 3.52.2
{'Output': {'dl_version': '3.52.2', 'match': '3.52.2'}}
URLTextSearcher
{'Input': {'re_pattern': '"(?P<url>https://.*/client/FileZilla_.*_macosx-x86\\S+)"',
           'result_output_var_name': 'match',
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: Found matching text (url): https://dl2.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bXczJRRhiASLX7Yyt3zCGA&x=1613292517
URLTextSearcher: Found matching text (match): https://dl2.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bXczJRRhiASLX7Yyt3zCGA&x=1613292517
{'Output': {'match': 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bXczJRRhiASLX7Yyt3zCGA&x=1613292517',
            'url': 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bXczJRRhiASLX7Yyt3zCGA&x=1613292517'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': True,
           'filename': 'FileZilla-3.52.2.tar.bz2',
           'url': 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bXczJRRhiASLX7Yyt3zCGA&x=1613292517'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FileZilla/downloads/FileZilla-3.52.2.tar.bz2
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FileZilla/downloads/FileZilla-3.52.2.tar.bz2'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
StopProcessingIf
{'Input': {'predicate': 'download_changed == FALSE'}}
StopProcessingIf: (download_changed == FALSE) is True
{'Output': {'stop_processing_recipe': True}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FileZilla/receipts/FileZilla-stable.download-receipt-20210213-234838.plist

Nothing downloaded, packaged or imported.
```

## ✅ FileZilla/FileZilla-stable.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/FileZilla/FileZilla-stable.pkg.recipe
Processing ~/Developer/_personal/sheepdog/repos/grahampugh-recipes/FileZilla/FileZilla-stable.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '<p>The latest stable version of FileZilla Client is '
                         '(?P<dl_version>.*)<\\/p>',
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (dl_version): 3.52.2
URLTextSearcher: Found matching text (match): 3.52.2
{'Output': {'dl_version': '3.52.2', 'match': '3.52.2'}}
URLTextSearcher
{'Input': {'re_pattern': '"(?P<url>https://.*/client/FileZilla_.*_macosx-x86\\S+)"',
           'result_output_var_name': 'match',
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: Found matching text (url): https://dl3.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bVm5mGT42VqJ0Ac5lQ-W5g&x=1613292442
URLTextSearcher: Found matching text (match): https://dl3.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bVm5mGT42VqJ0Ac5lQ-W5g&x=1613292442
{'Output': {'match': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bVm5mGT42VqJ0Ac5lQ-W5g&x=1613292442',
            'url': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bVm5mGT42VqJ0Ac5lQ-W5g&x=1613292442'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': True,
           'filename': 'FileZilla-3.52.2.tar.bz2',
           'url': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.52.2_macosx-x86.app.tar.bz2?h=bVm5mGT42VqJ0Ac5lQ-W5g&x=1613292442'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 18 Jan 2021 14:02:35 GMT
URLDownloader: Storing new ETag header: "600594fb-d8be62"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla-3.52.2.tar.bz2
{'Output': {'download_changed': True,
            'etag': '"600594fb-d8be62"',
            'last_modified': 'Mon, 18 Jan 2021 14:02:35 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla-3.52.2.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla-3.52.2.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
StopProcessingIf
{'Input': {'predicate': 'download_changed == FALSE'}}
StopProcessingIf: (download_changed == FALSE) is False
{'Output': {}}
Unarchiver
{'Input': {'archive_format': 'tar_bzip2',
           'archive_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla-3.52.2.tar.bz2',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla'}}
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla-3.52.2.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/*.app',
           'force_pkg_build': True}}
AppPkgCreator: Using path '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/FileZilla.app' matched from globbed '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/*.app'.
AppPkgCreator: Version: 3.52.2
AppPkgCreator: BundleID: org.filezilla-project.filezilla
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla/FileZilla.app to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/payload/Applications/FileZilla.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.filezilla-project.filezilla',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/FileZilla-3.52.2.pkg',
                                                        'version': '3.52.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.52.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/receipts/FileZilla-stable.pkg-receipt-20210213-234737.plist

The following new items were downloaded:
    Download Path                                                                                                        
    -------------                                                                                                        
    ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/downloads/FileZilla-3.52.2.tar.bz2  

The following packages were built:
    Identifier                       Version  Pkg Path                                                                                               
    ----------                       -------  --------                                                                                               
    org.filezilla-project.filezilla  3.52.2   ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.FileZilla/FileZilla-3.52.2.pkg  
```

## ✅ KNIME/KNIME.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/KNIME/KNIME.pkg.recipe
Processing repos/grahampugh-recipes/KNIME/KNIME.pkg.recipe...
URLDownloader
{'Input': {'filename': 'KNIME.dmg',
           'url': 'https://download.knime.org/analytics-platform/macosx/knime-latest-app.macosx.cocoa.x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.KNIME/downloads/KNIME.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.KNIME/downloads/KNIME.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
StopProcessingIf
{'Input': {'predicate': 'download_changed == FALSE'}}
StopProcessingIf: (download_changed == FALSE) is True
{'Output': {'stop_processing_recipe': True}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.KNIME/receipts/KNIME.pkg-receipt-20210213-233425.plist

Nothing downloaded, packaged or imported.
```

## ✅ Riot/Riot.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/Riot/Riot.pkg.recipe
Processing repos/grahampugh-recipes/Riot/Riot.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'This recipe has been deprecated, as Riot has '
                              'been renamed to Element (Riot). Please use the '
                              'Element recipes instead.'}}
DeprecationWarning: This recipe has been deprecated, as Riot has been renamed to Element (Riot). Please use the Element recipes instead.
{'Output': {'deprecation_summary_result': {'data': {'name': 'Riot.pkg',
                                                    'warning': 'This recipe '
                                                               'has been '
                                                               'deprecated, as '
                                                               'Riot has been '
                                                               'renamed to '
                                                               'Element '
                                                               '(Riot). Please '
                                                               'use the '
                                                               'Element '
                                                               'recipes '
                                                               'instead.'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
URLTextSearcher
{'Input': {'re_pattern': '"(?P<match>https://packages\\.riot\\.im/desktop/install/macos/Riot-.*\\.dmg)"',
           'url': 'https://riot.im/download/desktop/index.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://packages.riot.im/desktop/install/macos/Riot-1.6.8.dmg
{'Output': {'match': 'https://packages.riot.im/desktop/install/macos/Riot-1.6.8.dmg'}}
URLDownloader
{'Input': {'filename': 'Riot.dmg',
           'url': 'https://packages.riot.im/desktop/install/macos/Riot-1.6.8.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/downloads/Riot.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/downloads/Riot.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/downloads/Riot.dmg/Riot.app',
           'requirement': 'identifier "im.riot.app" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7J4U792NQT"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/downloads/Riot.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5tHa6m/Riot.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5tHa6m/Riot.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5tHa6m/Riot.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/downloads/Riot.dmg/Riot.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/downloads/Riot.dmg
Versioner: Found version 1.6.8 in file /private/tmp/dmg.BdL6px/Riot.app/Contents/Info.plist
{'Output': {'version': '1.6.8'}}
DeprecationWarning
{'Input': {'warning_message': 'This recipe has been deprecated, as Riot has '
                              'been renamed to Element (Riot). Please use the '
                              'Element recipes instead.'}}
DeprecationWarning: This recipe has been deprecated, as Riot has been renamed to Element (Riot). Please use the Element recipes instead.
{'Output': {'deprecation_summary_result': {'data': {'name': 'Riot.pkg',
                                                    'warning': 'This recipe '
                                                               'has been '
                                                               'deprecated, as '
                                                               'Riot has been '
                                                               'renamed to '
                                                               'Element '
                                                               '(Riot). Please '
                                                               'use the '
                                                               'Element '
                                                               'recipes '
                                                               'instead.'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
AppPkgCreator
{'Input': {'version': '1.6.8'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/downloads/Riot.dmg
AppPkgCreator: Using path '/private/tmp/dmg.n7SrXy/Riot.app' matched from globbed '/private/tmp/dmg.n7SrXy/*.app'.
AppPkgCreator: BundleID: im.riot.app
AppPkgCreator: Copied /private/tmp/dmg.n7SrXy/Riot.app to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/payload/Applications/Riot.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'im.riot.app',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/Riot-1.6.8.pkg',
                                                        'version': '1.6.8'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.6.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/receipts/Riot.pkg-receipt-20210213-233453.plist

The following recipes have deprecation warnings:
    Name      Warning                                                                                                               
    ----      -------                                                                                                               
    Riot.pkg  This recipe has been deprecated, as Riot has been renamed to Element (Riot). Please use the Element recipes instead.  
    Riot.pkg  This recipe has been deprecated, as Riot has been renamed to Element (Riot). Please use the Element recipes instead.  

The following packages were built:
    Identifier   Version  Pkg Path                                                                                    
    ----------   -------  --------                                                                                    
    im.riot.app  1.6.8    ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.Riot/Riot-1.6.8.pkg  
```

## ✅ ThinLincClient/ThinLincClient.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahampugh-recipes/ThinLincClient/ThinLincClient.pkg.recipe
Processing repos/grahampugh-recipes/ThinLincClient/ThinLincClient.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '"(?P<match>/downloads/clients/tl.*-client-macos\\.iso)"',
           'result_output_var_name': 'url',
           'url': 'https://www.cendio.com/thinlinc/download'}}
URLTextSearcher: Found matching text (match): /downloads/clients/tl-4.12.1_6733-client-macos.iso
URLTextSearcher: Found matching text (url): /downloads/clients/tl-4.12.1_6733-client-macos.iso
{'Output': {'match': '/downloads/clients/tl-4.12.1_6733-client-macos.iso',
            'url': '/downloads/clients/tl-4.12.1_6733-client-macos.iso'}}
URLDownloader
{'Input': {'filename': 'ThinLincClient.iso',
           'url': 'https://www.cendio.com/downloads/clients/tl-4.12.1_6733-client-macos.iso'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.ThinLincClient/downloads/ThinLincClient.iso
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.ThinLincClient/downloads/ThinLincClient.iso'}}
StopProcessingIf
{'Input': {'predicate': 'download_changed == FALSE'}}
StopProcessingIf: (download_changed == FALSE) is True
{'Output': {'stop_processing_recipe': True}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.ThinLincClient/receipts/ThinLincClient.pkg-receipt-20210213-233457.plist

Nothing downloaded, packaged or imported.
```
