### PR TITLE
Update LogitechPresentation.download.recipe

### DIFF
--- a/LogitechPresentation/LogitechPresentation.download.recipe
+++ b/LogitechPresentation/LogitechPresentation.download.recipe
@@ -24,8 +24,6 @@
 				<string>(?P&lt;url&gt;https:\/\/download01\.logi\.com\/web\/ftp\/pub\/techsupport\/presentation\/LogiPresentation_(?P&lt;version&gt;.*?)\.dmg)</string>
 				<key>url</key>
 				<string>https://support.logi.com/api/v2/help_center/en-gb/articles.json?label_names=webcontent=productdownload,webproduct=f7f7f812-7db0-11e9-b911-cb2c3611cd40</string>
-				<key>user-agent</key>
-				<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/LogitechPresentation/LogitechPresentation.download.recipe
+++ b/LogitechPresentation/LogitechPresentation.download.recipe
@@ -23,7 +23,7 @@
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;https:\/\/download01\.logi\.com\/web\/ftp\/pub\/techsupport\/presentation\/LogiPresentation_(?P&lt;version&gt;.*?)\.dmg)</string>
 				<key>url</key>
-				<string>https://www.logitech.com/en-gb/product/spotlight-presentation-remote/page/spotlight-features</string>
+				<string>https://support.logi.com/api/v2/help_center/en-gb/articles.json?label_names=webcontent=productdownload,webproduct=f7f7f812-7db0-11e9-b911-cb2c3611cd40</string>
 				<key>user-agent</key>
 				<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36</string>
 			</dict>


### PR DESCRIPTION
Logitech broke the download URL - but I sniffed out this API endpoint (which we can incidentally reuse for other titles - e.g. I have a recipe for Logitech Camera Settings which uses it).