### PR TITLE
Update AmazonCorrettoJDK11 pkg recipe search url to use github releases

### DIFF
--- a/AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe
+++ b/AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;https://.*?amazon-corretto-11.*?-macosx-x64\.tar\.gz)</string>
 		<key>SEARCH_URL</key>
-		<string>https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html</string>
+		<string>https://github.com/corretto/corretto-11/releases</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
## changes
- updates AmazonCorrettoJDK11.pkg.recipe search path to use github releases when discovering latest version (CorrettoJDK8 recipe does this already)

## testing
- ran updated recipe, latest version of corretto11 was discovered and downloaded

```
Processing ./AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe...
WARNING: ./AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): https://corretto.aws/downloads/resources/11.0.10.9.1/amazon-corretto-11.0.10.9.1-macosx-x64.tar.gz
URLTextSearcher: Found matching text (match): https://corretto.aws/downloads/resources/11.0.10.9.1/amazon-corretto-11.0.10.9.1-macosx-x64.tar.gz
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 23 Mar 2021 17:04:40 GMT
URLDownloader: Storing new ETag header: "e540ce083b87a82fbaa8564b6b17e541"
URLDownloader: Downloaded /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/downloads/amazon-corretto-11.0.10.9.1-macosx-x64.tar.gz
EndOfCheckPhase
PkgRootCreator
PkgRootCreator: Created /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot
PkgRootCreator: Created /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot/Library
PkgRootCreator: Created /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot/Library/Java
PkgRootCreator: Created /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot/Library/Java/JavaVirtualMachines
Unarchiver
Unarchiver: Guessed archive format 'tar_gzip' from filename amazon-corretto-11.0.10.9.1-macosx-x64.tar.gz
Unarchiver: Unarchived /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/downloads/amazon-corretto-11.0.10.9.1-macosx-x64.tar.gz to /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot/Library/Java/JavaVirtualMachines
FileFinder
FileFinder: Found file match: '/tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Info.plist' from globbed '/tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Info.plist'
Versioner
Versioner: Found version 11.0.10.9.1 in file /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Info.plist
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PathDeleter
PathDeleter: Deleted /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/pkgroot
Receipt written to /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/receipts/AmazonCorrettoJDK11.pkg-receipt-20210409-095259.plist

The following new items were downloaded:
    Download Path
    -------------
    /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/downloads/amazon-corretto-11.0.10.9.1-macosx-x64.tar.gz

The following packages were built:
    Identifier                  Version      Pkg Path
    ----------                  -------      --------
    com.amazon.corretto-11.jdk  11.0.10.9.1  /tmp/autopkg_cache/com.github.grahampugh.recipes.pkg.AmazonCorrettoJava11/AmazonCorrettoJDK11-11.0.10.9.1.pkg
```