### PR TITLE
Patch 1

### DIFF
--- a/CommonProcessors/JSSRecipeReceiptChecker.py
+++ b/CommonProcessors/JSSRecipeReceiptChecker.py
@@ -78,7 +78,8 @@ class JSSRecipeReceiptChecker(Processor):
         """do the main thing"""
         name = self.env.get("name")
         recipe_name = self.env.get("RECIPE_NAME")
-        cache_dir = expanduser(self.env.get("cache_dir"))
+        cache_dir = expanduser(self.env.get(
+            "cache_dir", "~/Library/AutoPkg/Cache"))
         version_found = False
 
         if recipe_name:

--- a/CommonProcessors/JSSRecipeReceiptChecker.py
+++ b/CommonProcessors/JSSRecipeReceiptChecker.py
@@ -16,7 +16,11 @@
 """See docstring for JSSRecipeReceiptChecker class"""
 
 from __future__ import absolute_import
-import plistlib
+
+try:
+    from plistlib import load as plistReader # Python 3
+except:
+    from plistlib import readPlist as plistReader # Python 2
 
 from glob import iglob
 from os.path import expanduser, getmtime, exists
@@ -98,7 +102,9 @@ class JSSRecipeReceiptChecker(Processor):
 
             self.output("Receipt: {}".format(receipt))
 
-            plist = plistlib.readPlist(receipt)
+            with open(receipt, 'rb') as plist_receipt:
+                plist = plistReader(plist_receipt)
+
             i = 0
             while i < len(plist):
                 try:

--- a/CommonProcessors/JSSRecipeReceiptChecker.py
+++ b/CommonProcessors/JSSRecipeReceiptChecker.py
@@ -38,7 +38,7 @@ class JSSRecipeReceiptChecker(Processor):
                 "from which we want to read the receipt. This is all we "
                 "need to construct the override path."
             ),
-            "required": True,
+            "required": False,
         },
         "RECIPE_NAME": {
             "description": (
@@ -82,8 +82,12 @@ class JSSRecipeReceiptChecker(Processor):
             "cache_dir", "~/Library/AutoPkg/Cache"))
         version_found = False
 
-        if recipe_name:
-            name = recipe_name
+        if not name:
+            if recipe_name:
+                name = recipe_name
+            else:
+                raise ProcessorError(
+                    "Either 'name' or 'recipe_name' must be provided.")
 
         receipt_number = 0
         while not version_found:


### PR DESCRIPTION
This patch doesn't change any functionality, it simply provides the functionality that seems to be described in the processor -- at least, that's how I read it.

Summary:
- Actually set the default cache_dir if not provided
- Allow for either name or recipe_name to be used
- Add support for Python3 plistlib
  - Switched to use `plistlib.load` instead of `plistlib.readPlist` if available