### PR TITLE
Allow for different (non-standard?) recipe identifiers

### DIFF
--- a/CommonProcessors/JSSRecipeReceiptChecker.py
+++ b/CommonProcessors/JSSRecipeReceiptChecker.py
@@ -78,7 +78,8 @@ class JSSRecipeReceiptChecker(Processor):
         """do the main thing"""
         name = self.env.get("name")
         recipe_name = self.env.get("RECIPE_NAME")
-        cache_dir = expanduser(self.env.get("cache_dir"))
+        cache_dir = expanduser(self.env.get(
+            "cache_dir", "~/Library/AutoPkg/Cache"))
         version_found = False
 
         if recipe_name:

--- a/CommonProcessors/JSSRecipeReceiptChecker.py
+++ b/CommonProcessors/JSSRecipeReceiptChecker.py
@@ -38,7 +38,7 @@ class JSSRecipeReceiptChecker(Processor):
                 "from which we want to read the receipt. This is all we "
                 "need to construct the override path."
             ),
-            "required": True,
+            "required": False,
         },
         "RECIPE_NAME": {
             "description": (
@@ -82,8 +82,12 @@ class JSSRecipeReceiptChecker(Processor):
             "cache_dir", "~/Library/AutoPkg/Cache"))
         version_found = False
 
-        if recipe_name:
-            name = recipe_name
+        if not name:
+            if recipe_name:
+                name = recipe_name
+            else:
+                raise ProcessorError(
+                    "Either 'name' or 'recipe_name' must be provided.")
 
         receipt_number = 0
         while not version_found:


### PR DESCRIPTION
This builds on Patch 1 #53.  It's possible it could be a breaking change for some.

- Support supplying full recipe identifiers
  - Change `RECIPE_NAME` to `recipe_id` in case recipe identifiers are not in the format of `local.jss.<NAME>`.

Basically, the existing code assumed recipe identifiers are in the format of `local.jss.<NAME>` (mine are not:  e.g. `myorgs.domain.<type>.<NAME>` -- this may not be standard, but how we set it up.)

This change simply allows someone to provide a different (non-standard?) identifier format when using this Processor.