### PR TITLE
Correct the description in JamfPolicyDeleter ReadMe

### DIFF
--- a/JamfUploaderProcessors/READMEs/JamfPolicyDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyDeleter.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-A processor for AutoPkg that will upload a policy to a Jamf Cloud or on-prem server. Optionally, an icon can be uploaded and associated with the policy.
+A processor for AutoPkg that will delete a policy from a Jamf Cloud or on-prem server.
 
 ## Input variables
 


### PR DESCRIPTION
New text is copied from the processor (old text was for JamfPolicyUploader).