### PR TITLE
limit file search

### DIFF
--- a/JamfUploaderProcessors/JamfComputerGroupUploader.py
+++ b/JamfUploaderProcessors/JamfComputerGroupUploader.py
@@ -241,26 +241,35 @@ class JamfComputerGroupUploader(Processor):
         return data
 
     def get_path_to_file(self, filename):
-        """AutoPkg is not very good at finding dependent files. This function will
-        look inside the search directories for any supplied file """
+        """AutoPkg is not very good at finding dependent files. This function
+        will look inside the search directories for any supplied file """
         # if the supplied file is not a path, use the override directory or
-        # ercipe dir if no override
+        # recipe dir if no override
         recipe_dir = self.env.get("RECIPE_DIR")
         filepath = os.path.join(recipe_dir, filename)
         if os.path.exists(filepath):
             self.output(f"File found at: {filepath}")
             return filepath
 
-        # if not found, search RECIPE_SEARCH_DIRS to look for it
-        search_dirs = self.env.get("RECIPE_SEARCH_DIRS")
-        matched_filepath = ""
-        for d in search_dirs:
-            for path in Path(d).rglob(filename):
-                matched_filepath = str(path)
-                break
-        if matched_filepath:
-            self.output(f"File found at: {matched_filepath}")
-            return matched_filepath
+        # if not found, search parent directories to look for it
+        if self.env.get("PARENT_RECIPES"):
+            # also look in the repos containing the parent recipes.
+            parent_recipe_dirs = list(
+                {os.path.dirname(item) for item in self.env["PARENT_RECIPES"]}
+            )
+            matched_filepath = ""
+            for d in parent_recipe_dirs:
+                # check if we are in the root of a parent repo, if not, ascend to the root
+                # note that if the parents are not in a git repo, only the same
+                # directory as the recipe will be searched for templates
+                if not os.path.isdir(os.path.join(d, ".git")):
+                    d = os.path.dirname(d)
+                for path in Path(d).rglob(filename):
+                    matched_filepath = str(path)
+                    break
+            if matched_filepath:
+                self.output(f"File found at: {matched_filepath}")
+                return matched_filepath
 
     def check_api_obj_id_from_name(self, jamf_url, object_type, object_name, enc_creds):
         """check if a Classic API object with the same name exists on the server"""

--- a/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
@@ -217,26 +217,35 @@ class JamfExtensionAttributeUploader(Processor):
             self.output(r.output, verbose_level=2)
 
     def get_path_to_file(self, filename):
-        """AutoPkg is not very good at finding dependent files. This function will
-        look inside the search directories for any supplied file """
+        """AutoPkg is not very good at finding dependent files. This function
+        will look inside the search directories for any supplied file """
         # if the supplied file is not a path, use the override directory or
-        # ercipe dir if no override
+        # recipe dir if no override
         recipe_dir = self.env.get("RECIPE_DIR")
         filepath = os.path.join(recipe_dir, filename)
         if os.path.exists(filepath):
             self.output(f"File found at: {filepath}")
             return filepath
 
-        # if not found, search RECIPE_SEARCH_DIRS to look for it
-        search_dirs = self.env.get("RECIPE_SEARCH_DIRS")
-        matched_filepath = ""
-        for d in search_dirs:
-            for path in Path(d).rglob(filename):
-                matched_filepath = str(path)
-                break
-        if matched_filepath:
-            self.output(f"File found at: {matched_filepath}")
-            return matched_filepath
+        # if not found, search parent directories to look for it
+        if self.env.get("PARENT_RECIPES"):
+            # also look in the repos containing the parent recipes.
+            parent_recipe_dirs = list(
+                {os.path.dirname(item) for item in self.env["PARENT_RECIPES"]}
+            )
+            matched_filepath = ""
+            for d in parent_recipe_dirs:
+                # check if we are in the root of a parent repo, if not, ascend to the root
+                # note that if the parents are not in a git repo, only the same
+                # directory as the recipe will be searched for templates
+                if not os.path.isdir(os.path.join(d, ".git")):
+                    d = os.path.dirname(d)
+                for path in Path(d).rglob(filename):
+                    matched_filepath = str(path)
+                    break
+            if matched_filepath:
+                self.output(f"File found at: {matched_filepath}")
+                return matched_filepath
 
     def check_api_obj_id_from_name(self, jamf_url, object_type, object_name, enc_creds):
         """check if a Classic API object with the same name exists on the server"""

--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -337,8 +337,7 @@ class JamfPackageUploader(Processor):
             ),
         ]
         self.output(
-            f"Mount command: {' '.join(mount_cmd)}",
-            verbose_level=3,
+            f"Mount command: {' '.join(mount_cmd)}", verbose_level=3,
         )
 
         r = subprocess.check_output(mount_cmd)
@@ -355,8 +354,7 @@ class JamfPackageUploader(Processor):
         try:
             r = subprocess.check_output(cmd)
             self.output(
-                r.decode("ascii"),
-                verbose_level=2,
+                r.decode("ascii"), verbose_level=2,
             )
         except subprocess.CalledProcessError:
             self.output("WARNING! Unmount failed.")
@@ -372,13 +370,11 @@ class JamfPackageUploader(Processor):
             else:
                 self.output("No existing package found")
                 self.output(
-                    f"Expected path: {existing_pkg_path}",
-                    verbose_level=2,
+                    f"Expected path: {existing_pkg_path}", verbose_level=2,
                 )
         else:
             self.output(
-                f"Expected path not found!: {path}",
-                verbose_level=2,
+                f"Expected path not found!: {path}", verbose_level=2,
             )
 
     def copy_pkg(self, mount_share, pkg_path, pkg_name):
@@ -414,8 +410,7 @@ class JamfPackageUploader(Processor):
                 for member in files:
                     zip_handle.write(os.path.join(root, member))
             self.output(
-                f"Closing: {zip_name}",
-                verbose_level=2,
+                f"Closing: {zip_name}", verbose_level=2,
             )
         return zip_name
 
@@ -490,16 +485,14 @@ class JamfPackageUploader(Processor):
             url = f"{jamf_url}/JSSResource/packages/id/0"
 
         self.output(
-            pkg_data,
-            verbose_level=2,
+            pkg_data, verbose_level=2,
         )
 
         count = 0
         while True:
             count += 1
             self.output(
-                f"Package metadata upload attempt {count}",
-                verbose_level=2,
+                f"Package metadata upload attempt {count}", verbose_level=2,
             )
 
             pkg_xml = self.write_temp_file(pkg_data)
@@ -512,8 +505,7 @@ class JamfPackageUploader(Processor):
                     "WARNING: Package metadata update did not succeed after 5 attempts"
                 )
                 self.output(
-                    f"HTTP POST Response Code: {r.status_code}",
-                    verbose_level=1,
+                    f"HTTP POST Response Code: {r.status_code}", verbose_level=1,
                 )
                 raise ProcessorError("ERROR: Package metadata upload failed ")
             sleep(30)
@@ -680,8 +672,7 @@ class JamfPackageUploader(Processor):
         # now process the package metadata if specified
         if pkg_id and (self.pkg_uploaded or self.replace_metadata):
             self.output(
-                "Updating package metadata for {}".format(pkg_id),
-                verbose_level=1,
+                "Updating package metadata for {}".format(pkg_id), verbose_level=1,
             )
             self.update_pkg_metadata(
                 self.jamf_url,
@@ -694,8 +685,7 @@ class JamfPackageUploader(Processor):
             self.pkg_metadata_updated = True
         elif self.smb_url and not pkg_id:
             self.output(
-                "Creating package metadata",
-                verbose_level=1,
+                "Creating package metadata", verbose_level=1,
             )
             self.update_pkg_metadata(
                 self.jamf_url,
@@ -707,8 +697,7 @@ class JamfPackageUploader(Processor):
             self.pkg_metadata_updated = True
         else:
             self.output(
-                "Not updating package metadata",
-                verbose_level=1,
+                "Not updating package metadata", verbose_level=1,
             )
             self.pkg_metadata_updated = False
 

--- a/JamfUploaderProcessors/JamfPolicyDeleter.py
+++ b/JamfUploaderProcessors/JamfPolicyDeleter.py
@@ -149,9 +149,7 @@ class JamfPolicyDeleter(Processor):
         subprocess.check_output(curl_cmd)
 
         r = namedtuple(
-            "r",
-            ["headers", "status_code", "output"],
-            defaults=(None, None, None)
+            "r", ["headers", "status_code", "output"], defaults=(None, None, None)
         )
         try:
             with open(headers_file, "r") as file:

--- a/JamfUploaderProcessors/JamfPolicyUploader.py
+++ b/JamfUploaderProcessors/JamfPolicyUploader.py
@@ -294,25 +294,34 @@ class JamfPolicyUploader(Processor):
 
     def get_path_to_file(self, filename):
         """AutoPkg is not very good at finding dependent files. This function
-        will look inside the search directories for any supplied file"""
+        will look inside the search directories for any supplied file """
         # if the supplied file is not a path, use the override directory or
-        # ercipe dir if no override
+        # recipe dir if no override
         recipe_dir = self.env.get("RECIPE_DIR")
         filepath = os.path.join(recipe_dir, filename)
         if os.path.exists(filepath):
             self.output(f"File found at: {filepath}")
             return filepath
 
-        # if not found, search RECIPE_SEARCH_DIRS to look for it
-        search_dirs = self.env.get("RECIPE_SEARCH_DIRS")
-        matched_filepath = ""
-        for d in search_dirs:
-            for path in Path(d).rglob(filename):
-                matched_filepath = str(path)
-                break
-        if matched_filepath:
-            self.output(f"File found at: {matched_filepath}")
-            return matched_filepath
+        # if not found, search parent directories to look for it
+        if self.env.get("PARENT_RECIPES"):
+            # also look in the repos containing the parent recipes.
+            parent_recipe_dirs = list(
+                {os.path.dirname(item) for item in self.env["PARENT_RECIPES"]}
+            )
+            matched_filepath = ""
+            for d in parent_recipe_dirs:
+                # check if we are in the root of a parent repo, if not, ascend to the root
+                # note that if the parents are not in a git repo, only the same
+                # directory as the recipe will be searched for templates
+                if not os.path.isdir(os.path.join(d, ".git")):
+                    d = os.path.dirname(d)
+                for path in Path(d).rglob(filename):
+                    matched_filepath = str(path)
+                    break
+            if matched_filepath:
+                self.output(f"File found at: {matched_filepath}")
+                return matched_filepath
 
     def get_api_obj_value_from_id(
         self, jamf_url, object_type, obj_id, obj_path, enc_creds

--- a/JamfUploaderProcessors/JamfUploaderProcessors.recipe.yaml
+++ b/JamfUploaderProcessors/JamfUploaderProcessors.recipe.yaml
@@ -1,5 +1,5 @@
-Description: "Recipe stub for any Processors in this directory.\n    "
+Description: Recipe stub for any Processors in this directory.
 Identifier: com.github.grahampugh.jamf-upload.processors
 Input: {}
-MinimumVersion: 0.4.0
+MinimumVersion: "2.3"
 Process: []

--- a/JamfUploaderProcessors/JamfUploaderSlacker.py
+++ b/JamfUploaderProcessors/JamfUploaderSlacker.py
@@ -237,8 +237,7 @@ class JamfUploaderSlacker(Processor):
         while True:
             count += 1
             self.output(
-                "Slack webhook post attempt {}".format(count),
-                verbose_level=2,
+                "Slack webhook post attempt {}".format(count), verbose_level=2,
             )
             r = self.curl(slack_webhook_url, slack_json)
             # check HTTP response


### PR DESCRIPTION
This patch limits the file search in the JamfUploader processors to the RECIPE_DIR folder (which is the RecipeOverrides folder if an override has been made, or the Repo directory if not), and the parent of that (i.e. the original repo if an override has been made, or the parent recipe's repo if not). 

Unfortunately, since RECIPE_DIR is not a constant folder, this does mean that a file in the parent recipe's folder may or may not be taken into account. But a file in the repo or the overrides folder should always be found.

This is a change from the current behaviour which searches all folders in RECIPE_SEARCH_DIRS, aimed at improving performance and limiting the risk of finding files of the same name in different repos.