### PR TITLE
Add `changed_policy_id` as a JamfPolicyUploader output variable

### DIFF
--- a/JamfUploaderProcessors/JamfComputerProfileUploader.py
+++ b/JamfUploaderProcessors/JamfComputerProfileUploader.py
@@ -448,8 +448,7 @@ class JamfComputerProfileUploader(Processor):
 
         # now extract the UUID from the existing payload
         existing_payload = plistlib.loads(existing_plist)
-        self.output("\nImported payload:", verbose_level=2)
-        self.output(existing_payload, verbose_level=2)
+        self.output("\nImported payload" + existing_payload, verbose_level=2)
         existing_uuid = existing_payload["PayloadUUID"]
         self.output(f"Existing UUID found: {existing_uuid}")
         return existing_uuid
@@ -473,7 +472,9 @@ class JamfComputerProfileUploader(Processor):
             mcx_preferences = plistlib.load(file)
 
         # substitute user-assignable keys
-        mcx_preferences = self.substitute_assignable_keys(mcx_preferences)
+        mcx_preferences = self.substitute_assignable_keys(
+            mcx_preferences, xml_escape=True
+        )
 
         self.output("Preferences contents:", verbose_level=2)
         self.output(mcx_preferences, verbose_level=2)

--- a/JamfUploaderProcessors/JamfComputerProfileUploader.py
+++ b/JamfUploaderProcessors/JamfComputerProfileUploader.py
@@ -448,7 +448,8 @@ class JamfComputerProfileUploader(Processor):
 
         # now extract the UUID from the existing payload
         existing_payload = plistlib.loads(existing_plist)
-        self.output("\nImported payload" + existing_payload, verbose_level=2)
+        self.output("Imported payload", verbose_level=2)
+        self.output(existing_payload, verbose_level=2)
         existing_uuid = existing_payload["PayloadUUID"]
         self.output(f"Existing UUID found: {existing_uuid}")
         return existing_uuid

--- a/JamfUploaderProcessors/JamfComputerProfileUploader.py
+++ b/JamfUploaderProcessors/JamfComputerProfileUploader.py
@@ -470,7 +470,6 @@ class JamfComputerProfileUploader(Processor):
         mobileconfig_data = {
             "PayloadDescription": description,
             "PayloadDisplayName": mobileconfig_name,
-            "PayloadEnabled": True,
             "PayloadOrganization": organization,
             "PayloadRemovalDisallowed": True,
             "PayloadScope": "System",

--- a/JamfUploaderProcessors/JamfComputerProfileUploader.py
+++ b/JamfUploaderProcessors/JamfComputerProfileUploader.py
@@ -356,6 +356,7 @@ class JamfComputerProfileUploader(Processor):
     def substitute_assignable_keys(self, data, xml_escape=False):
         """substitutes any key in the inputted text using the %MY_KEY% nomenclature"""
         # do a four-pass to ensure that all keys are substituted
+        print(data)  # TEMP
         loop = 5
         while loop > 0:
             loop = loop - 1
@@ -468,14 +469,15 @@ class JamfComputerProfileUploader(Processor):
         mobileconfig_uuid,
     ):
         """create a mobileconfig file using a payload file"""
-        # import plist and replace any substitutable keys
+        # import plist as text and replace any substitutable keys
         with open(payload_path, "rb") as file:
-            mcx_preferences = plistlib.load(file)
-
-        # substitute user-assignable keys
-        mcx_preferences = self.substitute_assignable_keys(
-            mcx_preferences, xml_escape=True
+            payload_text = file.read()
+        # substitute user-assignable keys (requires decode to string)
+        payload_text = self.substitute_assignable_keys(
+            (payload_text.decode()), xml_escape=True
         )
+        # now convert to data (requires encode back to bytes...)
+        mcx_preferences = plistlib.loads(str.encode(payload_text))
 
         self.output("Preferences contents:", verbose_level=2)
         self.output(mcx_preferences, verbose_level=2)

--- a/JamfUploaderProcessors/JamfPolicyUploader.py
+++ b/JamfUploaderProcessors/JamfPolicyUploader.py
@@ -74,6 +74,9 @@ class JamfPolicyUploader(Processor):
         "jamfpolicyuploader_summary_result": {
             "description": "Description of interesting results.",
         },
+        "changed_policy_id": {
+            "description": "Jamf object ID of the newly created or modified policy.",
+        },
     }
 
     # do not edit directly - copy from template
@@ -574,12 +577,21 @@ class JamfPolicyUploader(Processor):
                     verbose_level=1,
                 )
                 return
+            # Set the changed_policy_id to obj_id
+            self.env["changed_policy_id"] = obj_id
         else:
             # post the item
             r = self.upload_policy(
                 self.jamf_url, enc_creds, self.policy_name, template_xml,
             )
             self.policy_updated = True
+            # Set the changed_policy_id to the returned output's ID if and only
+            # if it can be determined
+            try:
+                changed_policy_id = ElementTree.fromstring(r.output).findtext("id")
+                self.evn["changed_policy_id"] = changed_policy_id
+            except UnboundLocalError:
+                pass
 
         # now upload the icon to the policy if specified in the args
         policy_icon_name = ""

--- a/JamfUploaderProcessors/JamfPolicyUploader.py
+++ b/JamfUploaderProcessors/JamfPolicyUploader.py
@@ -578,7 +578,7 @@ class JamfPolicyUploader(Processor):
                 )
                 return
             # Set the changed_policy_id to obj_id
-            self.env["changed_policy_id"] = obj_id
+            self.env["changed_policy_id"] = str(obj_id)
         else:
             # post the item
             r = self.upload_policy(
@@ -589,9 +589,9 @@ class JamfPolicyUploader(Processor):
             # if it can be determined
             try:
                 changed_policy_id = ElementTree.fromstring(r.output).findtext("id")
-                self.evn["changed_policy_id"] = changed_policy_id
+                self.env["changed_policy_id"] = str(changed_policy_id)
             except UnboundLocalError:
-                pass
+                self.env["changed_policy_id"] = "UNKNOWN_POLICY_ID"
 
         # now upload the icon to the policy if specified in the args
         policy_icon_name = ""

--- a/Jamf_Package_Only_Recipes/Nudge-pkg-upload.jamf.recipe.yaml
+++ b/Jamf_Package_Only_Recipes/Nudge-pkg-upload.jamf.recipe.yaml
@@ -1,11 +1,11 @@
 Comment: Created with Recipe Robot v2.3.0 (https://github.com/homebysix/recipe-robot)
 Description: Downloads the latest version of Nudge and uploads the package to Jamf.
-Identifier: com.github.grahampugh.jamf.Nudge
+Identifier: com.github.grahampugh.recipes.jamf.Nudge
 Input:
   CATEGORY: Productivity
   NAME: Nudge
 MinimumVersion: 1.0.0
-ParentRecipe: com.github.grahampugh.pkg.Nudge
+ParentRecipe: com.github.grahampugh.recipes.pkg.Nudge
 Process:
 - Arguments:
     category_name: '%CATEGORY%'

--- a/Jamf_Package_Only_Recipes/erase-install-pkg-upload.jamf.recipe.yaml
+++ b/Jamf_Package_Only_Recipes/erase-install-pkg-upload.jamf.recipe.yaml
@@ -1,5 +1,5 @@
 Comment: Options for INSTALLER are - erase-install, erase-install-nopython, erase-install-depnotify
-Description: Downloads the latest version of Nudge and uploads the package to Jamf.
+Description: Downloads the latest version of erase-install and uploads the package to Jamf.
 Identifier: com.github.grahampugh.recipes.jamf.erase-install
 Input:
   CATEGORY: Administration

--- a/Jamf_Package_Only_Recipes/erase-install-pkg-upload.jamf.recipe.yaml
+++ b/Jamf_Package_Only_Recipes/erase-install-pkg-upload.jamf.recipe.yaml
@@ -1,0 +1,16 @@
+Comment: Options for INSTALLER are - erase-install, erase-install-nopython, erase-install-depnotify
+Description: Downloads the latest version of Nudge and uploads the package to Jamf.
+Identifier: com.github.grahampugh.recipes.jamf.erase-install
+Input:
+  CATEGORY: Administration
+  NAME: erase-install
+  INSTALLER: erase-install-depnotify
+MinimumVersion: 1.0.0
+ParentRecipe: com.github.grahampugh.recipes.pkg.erase-install
+Process:
+  - Arguments:
+      category_name: "%CATEGORY%"
+    Processor: com.github.grahampugh.jamf-upload.processors/JamfCategoryUploader
+  - Arguments:
+      pkg_category: "%CATEGORY%"
+    Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader


### PR DESCRIPTION
This PR adds `changed_policy_id` as an output variable for the JamfPolicyUploader processor.

This new output variable makes the policy object ID of a created or modified policy available for use in subsequent processors.

Example use cases:

1. Adding `jamf policy -id <changed_policy_id>` to the "Execute Command" payload of a subsequent policy, for instances where using a custom trigger (e.g. `jamf policy -event <customer trigger>`) is not feasible due to multiple policies using the same trigger.
2. Using the policy ID in the policy name of a subsequent policy. For example, your organization's naming scheme might prefer to note the ID of a chained policy in a Self Service description, etc.

If applicable, `changed_policy_id` is populated by *each run of JamfPolicyUploader*. For this reason, you must structure your recipe's processors to consume the variable after JamfPolicyUploader runs, and before any additional JamfPolicyUploader processor runs.

For a brief example:

```xml
# JamfPolicyUploader updates the App Update policy
  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPolicyUploader
    Arguments:
      policy_name: "Install Example Package"
      policy_template: "Install-Policy-Template.xml"
      replace_policy: "True"

# JamfPolicyUploader updates the App Update policy
  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPolicyUploader
    Arguments:
      policy_name: "Update App (Runs Package Policy %changed_policy_id%)"
      policy_template: "Update-Policy-Template.xml"
      replace_policy: "True"
```

The first run of JamfPolicyUploader outputs the ID of the policy it creates or updates in the `changed_policy_id` variable. For example, the first run might create policy ID `101`.

The second run of JamfPolicyUploader would have access to that policy ID as `changed_policy_id` and variable substitution would populate the `policy_name` as "Update App (Runs Package Policy 101)".

If an error occurs and the object ID of a policy cannot be determined, the variable is returned as `UNKNOWN_POLICY_ID`.