### PR TITLE
Update LogitechPresentation.download.recipe.yaml

### DIFF
--- a/LogitechPresentation/LogitechPresentation.download.recipe.yaml
+++ b/LogitechPresentation/LogitechPresentation.download.recipe.yaml
@@ -8,12 +8,12 @@ Input:
 Process:
   - Processor: URLTextSearcher
     Arguments:
-      re_pattern: (?P<url>https:\/\/download01\.logi\.com\/web\/ftp\/pub\/techsupport\/presentation\/LogiPresentation_(?P<version>.*?)\.dmg)
+      re_pattern: Mac OS X.*?(https://download01\.logi\.com/web/ftp/pub/techsupport/presentation/LogiPresentation_.*?\.dmg)\\\"
       url: https://support.logi.com/api/v2/help_center/en-gb/articles.json?label_names=webcontent=productdownload,webproduct=f7f7f812-7db0-11e9-b911-cb2c3611cd40
 
   - Processor: URLDownloader
     Arguments:
-      url: "%url%"
+      url: "%match%"
 
   - Processor: EndOfCheckPhase
 


### PR DESCRIPTION
Download was failing prior:

• Updated re_pattern in URLTextSearcher
• Changed URLDownloader to use %match%

```
Processing /Users/ben/Git/other-recipes/grahampugh-recipes/LogitechPresentation/LogitechPresentation.download.recipe.yaml...
WARNING: /Users/ben/Git/other-recipes/grahampugh-recipes/LogitechPresentation/LogitechPresentation.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'Mac OS '
                         'X.*?(https://download01\\.logi\\.com/web/ftp/pub/techsupport/presentation/LogiPresentation_.*?\\.dmg)\\\\\\"',
           'url': 'https://support.logi.com/api/v2/help_center/en-gb/articles.json?label_names=webcontent=productdownload,webproduct=f7f7f812-7db0-11e9-b911-cb2c3611cd40'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://download01.logi.com/web/ftp/pub/techsupport/presentation/LogiPresentation_1.62.2.dmg
{'Output': {'match': 'https://download01.logi.com/web/ftp/pub/techsupport/presentation/LogiPresentation_1.62.2.dmg'}}
URLDownloader
{'Input': {'url': 'https://download01.logi.com/web/ftp/pub/techsupport/presentation/LogiPresentation_1.62.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 21 Oct 2020 20:30:18 GMT
URLDownloader: Storing new ETag header: "7458a64cb9ebc01b19a8d959d2537703"
URLDownloader: Downloaded /Users/ben/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_1.62.2.dmg
{'Output': {'download_changed': True,
            'etag': '"7458a64cb9ebc01b19a8d959d2537703"',
            'last_modified': 'Wed, 21 Oct 2020 20:30:18 GMT',
            'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_1.62.2.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ben/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_1.62.2.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_1.62.2.dmg/LogiPresentation '
                         'Installer.app',
           'requirement': 'identifier "com.logitech.presenter.installer" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'QED4VVPZWA'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_1.62.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.3YIYLu/LogiPresentation Installer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3YIYLu/LogiPresentation Installer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3YIYLu/LogiPresentation Installer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/receipts/LogitechPresentation.download.recipe-receipt-20211202-112444.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ben/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_1.62.2.dmg

```