### PR TITLE
Fixed os_requirements not being included correctly in pkg XML

### DIFF
--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -486,7 +486,7 @@ class JamfPackageUploader(Processor):
             + f"<priority>{pkg_metadata['priority']}</priority>"
             + f"<reboot_required>{pkg_metadata['reboot_required']}</reboot_required>"
             + f"<required_processor>{pkg_metadata['required_processor']}</required_processor>"
-            + f"<os_requirement>{pkg_metadata['os_requirement']}</os_requirement>"
+            + f"<os_requirements>{pkg_metadata['os_requirement']}</os_requirements>"
             + f"<hash_type>{hash_type}</hash_type>"
             + f"<hash_value>{hash_value}</hash_value>"
             + f"<send_notification>{pkg_metadata['send_notification']}</send_notification>"


### PR DESCRIPTION
This PR fixes `JamfPackageUploader` not correctly setting a package's OS requirements due to an incorrectly named XML key.

This change **only** changes the uploaded XML key from `os_requirement` to `os_requirements`, as detailed in the [Jamf API documentation](https://developer.jamf.com/jamf-pro/reference/createpackagebyid). The processor itself still accepts `os_requirement` as input. I haven't changed this, as people may be already using the `os_requirement` key in recipes, and I am unsure as to whether you want to match processor input variable names 1:1 with the XML key names used by Jamf.