### PR TITLE
Fixed os_requirements not being included correctly in pkg XML

### DIFF
--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -86,7 +86,7 @@ class JamfPackageUploader(JamfUploaderBase):
             ),
             "default": "",
         },
-        "os_requirement": {
+        "os_requirements": {
             "required": False,
             "description": "Package OS requirement",
             "default": "",
@@ -359,7 +359,7 @@ class JamfPackageUploader(JamfUploaderBase):
             + f"<priority>{pkg_metadata['priority']}</priority>"
             + f"<reboot_required>{pkg_metadata['reboot_required']}</reboot_required>"
             + f"<required_processor>{pkg_metadata['required_processor']}</required_processor>"
-            + f"<os_requirement>{pkg_metadata['os_requirement']}</os_requirement>"
+            + f"<os_requirements>{pkg_metadata['os_requirements']}</os_requirements>"
             + f"<hash_type>{hash_type}</hash_type>"
             + f"<hash_value>{hash_value}</hash_value>"
             + f"<send_notification>{pkg_metadata['send_notification']}</send_notification>"
@@ -454,7 +454,7 @@ class JamfPackageUploader(JamfUploaderBase):
             "notes": self.env.get("pkg_notes"),
             "reboot_required": self.reboot_required,
             "priority": self.env.get("pkg_priority"),
-            "os_requirement": self.env.get("os_requirement"),
+            "os_requirements": self.env.get("os_requirements"),
             "required_processor": self.env.get("required_processor"),
             "send_notification": self.send_notification,
         }

--- a/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
@@ -36,7 +36,7 @@ The pkg recipe must output pkg_path or this will fail.
   - **required:** False
   - **description:** Whether a package requires a reboot after installation.
   - **default:**
-- **os_requirement:**
+- **os_requirements:**
   - **required:** False
   - **description:** Package OS requirement
 - **required_processor:**


### PR DESCRIPTION
As discussed in #89, but this also changes the input keys for the processor.

This PR fixes `JamfPackageUploader` not correctly setting a package's OS requirements due to an incorrectly named XML key.

This changes the uploaded XML key from `os_requirement` to `os_requirements`, as detailed in the [Jamf API documentation](https://developer.jamf.com/jamf-pro/reference/createpackagebyid). The processor itself has also been modified to only accept `os_requirements` as an input key, and the README for the processor has also been updated to reflect this.

I'm also opening a similar PR against https://github.com/grahampugh/jamf-upload with the same changes.