### PR TITLE
Fix inconsistent/incorrect descriptions in JamfPolicyLogFlusher

### DIFF
--- a/JamfUploaderProcessors/JamfPolicyLogFlusher.py
+++ b/JamfUploaderProcessors/JamfPolicyLogFlusher.py
@@ -47,7 +47,7 @@ class JamfPolicyLogFlusher(JamfUploaderBase):
         },
         "policy_name": {
             "required": True,
-            "description": "Policy to delete",
+            "description": "Policy whose log is to be flushed",
             "default": "",
         },
         "logflush_interval": {

--- a/JamfUploaderProcessors/READMEs/JamfPolicyLogFlusher.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyLogFlusher.md
@@ -17,11 +17,11 @@ A processor for AutoPkg that will flush the logs of a policy on a Jamf Cloud or 
   - **description:** Password of api user, optionally set as a key in the com.github.autopkg preference file.
 - **policy_name:**
   - **required:** True
-  - **description:** Policy name
+  - **description:** Policy whose log is to be flushed
 - **interval:**
   - **required:** False
   - **description:** Interval of log to flush
-  - **default:** "Six Years"
+  - **default:** "Zero Days"
 
 ## Output variables
 


### PR DESCRIPTION
- In JamfPolicyLogFlusher.py, the input_variable description for policy_name incorrectly states that the policy will be deleted, not flushed.
- The ReadMe for JamfPolicyLogFlusher.py does not match the code (the policy_name descriptor is more accurate than the code but not particularly descriptive, and the interval does not match the code).

This PR fixes those documentation issues.