### PR TITLE
changed ParentRecipe

### DIFF
--- a/Jamf_Recipes/1Password.jamf.recipe
+++ b/Jamf_Recipes/1Password.jamf.recipe
@@ -36,7 +36,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>io.github.hjuutilainen.pkg.1Password</string>
+	<string>com.github.nstrauss.pkg.1Password</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
- changed `ParentRecipe` to com.github.nstrauss.pkg.1Password (this recipe has been updated to package the latest 1Password release, whereas the previous one was linked to a 1Password 7-specific recipe)