### PR TITLE
multirepo changes

### DIFF
--- a/AppleJava6/Java6Versioner.py
+++ b/AppleJava6/Java6Versioner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # 2017 Graham R Pugh
 #

--- a/CommonProcessors/ChoicesXMLGenerator.py
+++ b/CommonProcessors/ChoicesXMLGenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Graham Pugh
 #

--- a/CommonProcessors/JSSRecipeReceiptChecker.py
+++ b/CommonProcessors/JSSRecipeReceiptChecker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # 2019 Graham R Pugh
 #

--- a/CommonProcessors/SMBMounter.py
+++ b/CommonProcessors/SMBMounter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 
 """
 2020 Graham R Pugh

--- a/CommonProcessors/SMBUnmounter.py
+++ b/CommonProcessors/SMBUnmounter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 
 """
 2020 Graham R Pugh

--- a/CommonProcessors/WritePkgResultToJson.py
+++ b/CommonProcessors/WritePkgResultToJson.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # 2019 Graham R Pugh
 #

--- a/FileMakerProAdvanced/FilemakerProAdvancedUpdateExtractor.py
+++ b/FileMakerProAdvanced/FilemakerProAdvancedUpdateExtractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 # FilemakerProAdvancedUpdateDMGExtractor.py
 # Extracts a FileMaker updater package from a given DMG.
 #

--- a/JamfUploaderProcessors/CHANGELOG.md
+++ b/JamfUploaderProcessors/CHANGELOG.md
@@ -1,15 +1,19 @@
 # CHANGELOG
 
-| Date       | Notes |
-|------------|----------|----------------------------|
-| 2022-08-25 | Add `sleep` to all relevant processors |
-| 2022-06-24 | skip_metadata_upload in `JamfPackageUploader` |
-| 2022-01-31 | fix script url and add 405 error |
-| 2021-10-22 | Switch to token auth for Jamf Classic API, and move common functions into `JamfUploaderBase.py` |
-| 2021-10-22 | url fixes |
-| 2021-10-21 | Fixes for variable substitution. |
-| 2021-09-01 | Limit file search within repos. |
-| 2021-08-24 | Add AWS cookie checks. |
-| 2021-08-22 | Remove case-sensitivity of object name check. |
-| 2021-05-04 | Add `JamfComputerProfileUploader` processor, plus fix for #52. |
-| 2021-04-06 | Enable HTTP/2 transfer. |
+| Date       | Notes                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------ |
+| 2022-10-15 | Allow multiple SMB repos plus SMB + Cloud in `JamfPackageUploader`.                                                       |
+| 2022-10-08 | Fail properly for unsubstitutable variables.                                                     |
+| 2022-10-08 | Fail properly if cannot detemine the Jamf Pro version.                                           |
+| 2022-09-21 | Allow empty values for substitutable variables.                                                  |
+| 2022-08-25 | Add `sleep` to all relevant processors.                                                          |
+| 2022-06-24 | skip_metadata_upload in `JamfPackageUploader`.                                                   |
+| 2022-01-31 | fix script url and add 405 error.                                                                |
+| 2021-10-22 | Switch to token auth for Jamf Classic API, and move common functions into `JamfUploaderBase.py`. |
+| 2021-10-22 | url fixes.                                                                                       |
+| 2021-10-21 | Fixes for variable substitution.                                                                 |
+| 2021-09-01 | Limit file search within repos.                                                                  |
+| 2021-08-24 | Add AWS cookie checks.                                                                           |
+| 2021-08-22 | Remove case-sensitivity of object name check.                                                    |
+| 2021-05-04 | Add `JamfComputerProfileUploader` processor, plus fix for #52.                                   |
+| 2021-04-06 | Enable HTTP/2 transfer.                                                                          |

--- a/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
@@ -59,6 +59,11 @@ class JamfExtensionAttributeUploader(JamfUploaderBase):
             "description": "Overwrite an existing category if True.",
             "default": False,
         },
+        "ea_data_type": {
+            "required": False,
+            "description": "Data type for the EA. One of String, Integer or Date.",
+            "default": "String",
+        },
         "sleep": {
             "required": False,
             "description": "Pause after running this processor for specified seconds.",
@@ -76,6 +81,7 @@ class JamfExtensionAttributeUploader(JamfUploaderBase):
         self,
         jamf_url,
         ea_name,
+        ea_data_type,
         script_path,
         obj_id=None,
         enc_creds="",
@@ -101,7 +107,7 @@ class JamfExtensionAttributeUploader(JamfUploaderBase):
             + "<name>{}</name>".format(ea_name)
             + "<enabled>true</enabled>"
             + "<description/>"
-            + "<data_type>String</data_type>"
+            + "<data_type>{}</data_type>".format(ea_data_type)
             + "<input_type>"
             + "  <type>script</type>"
             + "  <platform>Mac</platform>"
@@ -166,6 +172,7 @@ class JamfExtensionAttributeUploader(JamfUploaderBase):
         self.ea_script_path = self.env.get("ea_script_path")
         self.ea_name = self.env.get("ea_name")
         self.replace = self.env.get("replace_ea")
+        self.ea_data_type = self.env.get("ea_data_type")
         self.sleep = self.env.get("sleep")
         # handle setting replace in overrides
         if not self.replace or self.replace == "False":
@@ -227,6 +234,7 @@ class JamfExtensionAttributeUploader(JamfUploaderBase):
         self.upload_ea(
             self.jamf_url,
             self.ea_name,
+            self.ea_data_type,
             self.ea_script_path,
             obj_id=obj_id,
             enc_creds=send_creds,

--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -132,40 +132,57 @@ class JamfPackageUploader(JamfUploaderBase):
         },
         "JSS_URL": {
             "required": True,
-            "description": "URL to a Jamf Pro server that the API user has write access "
-            "to, optionally set as a key in the com.github.autopkg "
-            "preference file.",
+            "description": "URL to a Jamf Pro server to which the API user has write access.",
         },
         "API_USERNAME": {
             "required": True,
-            "description": "Username of account with appropriate access to "
-            "jss, optionally set as a key in the com.github.autopkg "
-            "preference file.",
+            "description": "Username of account with appropriate API access to the "
+            "Jamf Pro Server.",
         },
         "API_PASSWORD": {
             "required": True,
-            "description": "Password of api user, optionally set as a key in "
-            "the com.github.autopkg preference file.",
+            "description": "Password of account with appropriate API access to the "
+            "Jamf Pro Server",
+        },
+        "CLOUD_DP": {
+            "required": False,
+            "description": "Indicates the presence of a Cloud Distribution Point. "
+            "The default is deliberately blank. If no SMB DP is configured, "
+            "the default setting assumes that the Cloud DP has been enabled. "
+            "If at least one SMB DP is configured, the default setting assumes "
+            "that no Cloud DP has been set. "
+            "This can be overridden by setting CLOUD_DP to True, in which case "
+            "packages will be uploaded to both a Cloud DP plus the SMB DP(s).",
+            "default": False,
         },
         "SMB_URL": {
             "required": False,
-            "description": "URL to a Jamf Pro fileshare distribution point "
-            "which should be in the form smb://server "
-            "preference file.",
+            "description": "URL to a Jamf Pro file share distribution point "
+            "which should be in the form smb://server/share "
+            "or a local DP in the form file://path. "
+            "Subsequent DPs can be configured using SMB2_URL, SMB3_URL etc. "
+            "Accompanying username and password must be supplied for each DP, e.g. "
+            "SMB2_USERNAME, SMB2_PASSWORD etc.",
             "default": "",
         },
         "SMB_USERNAME": {
             "required": False,
             "description": "Username of account with appropriate access to "
-            "jss, optionally set as a key in the com.github.autopkg "
-            "preference file.",
+            "a Jamf Pro fileshare distribution point.",
             "default": "",
         },
         "SMB_PASSWORD": {
             "required": False,
-            "description": "Password of api user, optionally set as a key in "
-            "the com.github.autopkg preference file.",
+            "description": "Password of account with appropriate access to "
+            "a Jamf Pro fileshare distribution point.",
             "default": "",
+        },
+        "SMB_SHARES": {
+            "required": False,
+            "description": "An array of dictionaries containing SMB_URL, SMB_USERNAME and "
+            "SMB_PASSWORD, as an alternative to individual keys. Any individual keys will "
+            "override this complete array. The array can only be provided via the AutoPkg "
+            "preferences file.",
         },
         "sleep": {
             "required": False,
@@ -212,14 +229,14 @@ class JamfPackageUploader(JamfUploaderBase):
         ]
         self.output(
             f"Mount command: {' '.join(mount_cmd)}",
-            verbose_level=3,
+            verbose_level=4,
         )
 
         r = subprocess.check_output(mount_cmd)
         self.output(
-            # r.decode("ascii"), verbose_level=2,
-            r,
-            verbose_level=2,
+            r.decode("ascii"),
+            # r,
+            verbose_level=4,
         )
 
     def umount_smb(self, mount_share):
@@ -640,7 +657,7 @@ class JamfPackageUploader(JamfUploaderBase):
         if not self.replace_metadata or self.replace_metadata == "False":
             self.replace_metadata = False
         self.skip_metadata_upload = self.env.get("skip_metadata_upload")
-        # handle setting replace_metadata in overrides
+        # handle setting skip_metadata_upload in overrides
         if not self.skip_metadata_upload or self.skip_metadata_upload == "False":
             self.skip_metadata_upload = False
         self.jcds_mode = self.env.get("jcds_mode")
@@ -650,12 +667,79 @@ class JamfPackageUploader(JamfUploaderBase):
         self.jamf_url = self.env.get("JSS_URL")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
-        self.smb_url = self.env.get("SMB_URL")
-        self.smb_user = self.env.get("SMB_USERNAME")
-        self.smb_password = self.env.get("SMB_PASSWORD")
+        self.cloud_dp = self.env.get("CLOUD_DP")
+        # handle setting jcds_mode in overrides
+        if not self.cloud_dp or self.cloud_dp == "False":
+            self.cloud_dp = False
         self.recipe_cache_dir = self.env.get("RECIPE_CACHE_DIR")
         self.pkg_uploaded = False
         self.pkg_metadata_updated = False
+
+        # Create a list of smb shares in tuples
+        self.smb_shares = []
+        if self.env.get("SMB_URL"):
+            if not self.env.get("SMB_USERNAME") or not self.env.get("SMB_PASSWORD"):
+                raise ProcessorError("SMB_URL defined but no credentials supplied.")
+            self.output(
+                "DP 1: {}, {}, pass len: {}".format(
+                    self.env.get("SMB_URL"),
+                    self.env.get("SMB_USERNAME"),
+                    len(self.env.get("SMB_PASSWORD")),
+                ),
+                verbose_level=2,
+            )
+            self.smb_shares.append(
+                (
+                    self.env.get("SMB_URL"),
+                    self.env.get("SMB_USERNAME"),
+                    self.env.get("SMB_PASSWORD"),
+                )
+            )
+            n = 2
+            while n > 0:
+                if self.env.get(f"SMB{n}_URL"):
+                    if not self.env.get(f"SMB{n}_USERNAME") or not self.env.get(
+                        f"SMB{n}_PASSWORD"
+                    ):
+                        raise ProcessorError(
+                            f"SMB{n}_URL defined but no credentials supplied."
+                        )
+                    self.output(
+                        "DP {}: {}, {}, pass len: {}".format(
+                            n,
+                            self.env.get(f"SMB{n}_URL"),
+                            self.env.get(f"SMB{n}_USERNAME"),
+                            len(self.env.get(f"SMB{n}_PASSWORD")),
+                        ),
+                        verbose_level=2,
+                    )
+                    self.smb_shares.append(
+                        (
+                            self.env.get(f"SMB{n}_URL"),
+                            self.env.get(f"SMB{n}_USERNAME"),
+                            self.env.get(f"SMB{n}_PASSWORD"),
+                        )
+                    )
+                    n = n + 1
+                else:
+                    self.output(f"DP {n}: not defined", verbose_level=3)
+                    n = 0
+        elif self.env.get("SMB_SHARES"):
+            smb_share_array = self.env.get("SMB_SHARES")
+            for share in smb_share_array:
+                if (
+                    not share["SMB_URL"]
+                    or not share["SMB_USERNAME"]
+                    or not share["SMB_PASSWORD"]
+                ):
+                    raise ProcessorError("Incorrect SMB credentials supplied.")
+                self.smb_shares.append(
+                    (
+                        share["SMB_URL"],
+                        share["SMB_USERNAME"],
+                        share["SMB_PASSWORD"],
+                    )
+                )
 
         # create a dictionary of package metadata from the inputs
         self.pkg_category = self.env.get("pkg_category")
@@ -720,12 +804,18 @@ class JamfPackageUploader(JamfUploaderBase):
             else:
                 pkg_id = 0
 
-        # process for SMB shares if defined
-        if self.smb_url:
-            # mount the share
-            self.mount_smb(self.smb_url, self.smb_user, self.smb_password)
+        # Process for SMB shares if defined
+        self.output(
+            "Number of File Share DPs: " + str(len(self.smb_shares)), verbose_level=2
+        )
+        for smb_share in self.smb_shares:
+            smb_url, smb_user, smb_password = smb_share[0], smb_share[1], smb_share[2]
+            self.output(f"Begin upload to File Share DP {smb_url}", verbose_level=1)
+            if "smb://" in smb_url:
+                # mount the share
+                self.mount_smb(smb_url, smb_user, smb_password)
             # check for existing package
-            local_pkg = self.check_local_pkg(self.smb_url, self.pkg_name)
+            local_pkg = self.check_local_pkg(smb_url, self.pkg_name)
             if not local_pkg or self.replace:
                 if self.replace:
                     self.output(
@@ -735,25 +825,34 @@ class JamfPackageUploader(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # copy the file
-                self.copy_pkg(self.smb_url, self.pkg_path, self.pkg_name)
-                # unmount the share
-                self.umount_smb(self.smb_url)
-                self.pkg_uploaded = True
+                self.copy_pkg(smb_url, self.pkg_path, self.pkg_name)
+                if "smb://" in smb_url:
+                    # unmount the share
+                    self.umount_smb(smb_url)
+                # Don't set this property if
+                # 1. We need to upload to the cloud (self.cloud_dp == True)
+                # 2. We have more SMB shares to process
+                if not self.cloud_dp and (
+                    len(self.smb_shares) - 1
+                ) == self.smb_shares.index(smb_share):
+                    self.pkg_uploaded = True
             else:
                 self.output(
                     f"Not replacing existing {self.pkg_name} as 'replace_pkg' is set to "
                     f"{self.replace}. Use replace_pkg='True' to enforce."
                 )
-                # unmount the share
-                self.umount_smb(self.smb_url)
-                if not self.replace_metadata:
+                if "smb://" in smb_url:
+                    # unmount the share
+                    self.umount_smb(smb_url)
+                if self.smb_shares and not self.replace_metadata:
                     # even if we don't upload a package, we still need to pass it on so that a
-                    # policy processor can use it
+                    # subsequent processor can use it
                     self.env["pkg_name"] = self.pkg_name
                     self.pkg_uploaded = False
 
         # otherwise process for cloud DP
-        else:
+        if self.cloud_dp or not self.smb_shares:
+            self.output("Handling Cloud Distribution Point", verbose_level=2)
             if obj_id == "-1" or self.replace:
                 if self.replace:
                     self.output(
@@ -873,7 +972,7 @@ class JamfPackageUploader(JamfUploaderBase):
                 token=token,
             )
             self.pkg_metadata_updated = True
-        elif self.smb_url and not pkg_id:
+        elif self.smb_shares and not pkg_id:
             self.output(
                 "Creating package metadata",
                 verbose_level=1,
@@ -901,12 +1000,19 @@ class JamfPackageUploader(JamfUploaderBase):
         if self.pkg_metadata_updated or self.pkg_uploaded:
             self.env["jamfpackageuploader_summary_result"] = {
                 "summary_text": "The following packages were uploaded to or updated in Jamf Pro:",
-                "report_fields": ["pkg_path", "pkg_name", "version", "category"],
+                "report_fields": [
+                    "category",
+                    "name",
+                    "pkg_name",
+                    "pkg_path",
+                    "version",
+                ],
                 "data": {
-                    "pkg_path": self.pkg_path,
-                    "pkg_name": self.pkg_name,
-                    "version": self.version,
                     "category": self.pkg_category,
+                    "name": str(self.env.get("NAME")),
+                    "pkg_name": self.pkg_name,
+                    "pkg_path": self.pkg_path,
+                    "version": self.version,
                 },
             }
 

--- a/JamfUploaderProcessors/JamfPolicyLogFlusher.py
+++ b/JamfUploaderProcessors/JamfPolicyLogFlusher.py
@@ -48,7 +48,7 @@ class JamfPolicyLogFlusher(JamfUploaderBase):
         },
         "policy_name": {
             "required": True,
-            "description": "Policy to delete",
+            "description": "Policy whose log is to be flushed",
             "default": "",
         },
         "logflush_interval": {

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -462,9 +462,9 @@ class JamfUploaderBase(Processor):
                 jamf_pro_version = str(r.output["version"])
                 self.output(f"Jamf Pro Version: {jamf_pro_version}")
                 return jamf_pro_version
-            except KeyError:
-                self.output("ERROR: No version received")
-                return
+            except (KeyError, AttributeError) as error:
+                self.output(f"ERROR: No version received.  Error:\n{error}")
+                raise ProcessorError("Unable to determine version of Jamf Pro") from error
 
     def validate_jamf_pro_version(self, jamf_url, token):
         """return true if Jamf Pro version is 10.35 or greater"""
@@ -529,7 +529,7 @@ class JamfUploaderBase(Processor):
                 break
             found_keys = [i.replace("%", "") for i in found_keys]
             for found_key in found_keys:
-                if self.env.get(found_key):
+                if self.env.get(found_key) is not None:
                     self.output(
                         (
                             f"Replacing any instances of '{found_key}' with",
@@ -546,7 +546,7 @@ class JamfUploaderBase(Processor):
                     self.output(
                         f"WARNING: '{found_key}' has no replacement object!",
                     )
-                    raise ProcessorError("Unsubstitutable key in template found")
+                    raise ProcessorError(f"Unsubstitutable key in template found: '{found_key}'")
         return data
 
     def substitute_limited_assignable_keys(

--- a/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
@@ -25,6 +25,10 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
   - **required**: False
   - **description**: Overwrite an existing Extension Attribute if True.
   - **default**: False
+- **ea_data_type**:
+  - **required**: False
+  - **description**: Data type for the EA. One of String, Integer or Date.
+  - **default**: String
 
 ## Output variables
 

--- a/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
@@ -63,22 +63,28 @@ Can be run as a post-processor for a pkg recipe or in a child recipe. The parent
   - **default:** False
 - **JSS_URL:**
   - **required:** True
-  - **description:** URL to a Jamf Pro server that the API user has write access to, optionally set as a key in the com.github.autopkg preference file.
+  - **description:** URL to a Jamf Pro server to which the API user has write access.
 - **API_USERNAME:**
   - **required:** True
-  - **description:** Username of account with appropriate access to jss, optionally set as a key in the com.github.autopkg preference file.
+  - **description:** Username of account with appropriate API access to the Jamf Pro Server.
 - **API_PASSWORD:**
   - **required:** True
-  - **description:** Password of api user, optionally set as a key in the com.github.autopkg preference file.
+  - **description:** Password of account with appropriate API access to the Jamf Pro Server..
+- **CLOUD_DP:**
+  - **required:** False
+  - **description:** Indicates the presence of a Cloud Distribution Point. The default is deliberately blank. If no SMB DP is configured, the default setting assumes that the Cloud DP has been enabled. If at least one SMB DP is configured, the default setting assumes that no Cloud DP has been set. This can be overridden by setting `CLOUD_DP` to `True`, in which case packages will be uploaded to both a Cloud DP plus the SMB DP(s)."
 - **SMB_URL:**
   - **required:** False
-  - **description:** URL to a Jamf Pro fileshare distribution point which should be in the form `smb://server/share`.
+  - **description:** URL to a Jamf Pro file share distribution point which should be in the form `smb://server/share` or a local DP in the form `file://path`. Subsequent DPs can be configured using `SMB2_URL`, `SMB3_URL` etc. Accompanying username and password must be supplied for each DP, e.g. `SMB2_USERNAME`, `SMB2_PASSWORD` etc.
 - **SMB_USERNAME:**
   - **required:** False
-  - **description:** Username of account with appropriate access to jss, optionally set as a key in the com.github.autopkg preference file.
+  - **description:** Username of account with appropriate access to a Jamf Pro fileshare distribution point.
 - **SMB_PASSWORD:**
   - **required:** False
-  - **description:** Password of api user, optionally set as a key in the com.github.autopkg preference file.
+  - **description:** Password of account with appropriate access to a Jamf Pro fileshare distribution point.
+- **SMB_SHARES:**
+  - **required:** False
+  - **description:** An array of dictionaries containing `SMB_URL`, `SMB_USERNAME` and `SMB_PASSWORD`, as an alternative to individual keys. Any individual keys will override this complete array. The array can only be provided via the AutoPkg preferences file.
 
 ## Output variables
 

--- a/JamfUploaderProcessors/READMEs/JamfPolicyLogFlusher.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyLogFlusher.md
@@ -17,11 +17,11 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
   - **description:** Password of api user, optionally set as a key in the com.github.autopkg preference file.
 - **policy_name:**
   - **required:** True
-  - **description:** Policy name
+  - **description:** Policy whose log is to be flushed
 - **interval:**
   - **required:** False
   - **description:** Interval of log to flush
-  - **default:** "Six Years"
+  - **default:** "Zero Days"
 
 ## Output variables
 

--- a/Parallels/ParallelsDesktopPackager.py
+++ b/Parallels/ParallelsDesktopPackager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2017 Graham Pugh
 #

--- a/PostProcessors/LastRecipeRunResult.py
+++ b/PostProcessors/LastRecipeRunResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # 2019 Graham R Pugh
 #

--- a/PostProcessors/slacker.py
+++ b/PostProcessors/slacker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2017 Graham Pugh
 #

--- a/PreProcessors/LastRecipeRunChecker.py
+++ b/PreProcessors/LastRecipeRunChecker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # 2019 Graham R Pugh
 #


### PR DESCRIPTION
Adds functionality for multiple SMB repos, plus the ability to specify both a Cloud Distribution Point and one or more SMB repos. These changes only affect `JamfPackageUploader`.

For details on how this works, see https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors#advanced-settings-for-distribution-points-coming-soon.

In short:
- If you are using Jamf Cloud with the JCDS: no change
- If you are on-premises, using a single SMB distribution point: no change
- If you have multiple SMB repos, you can now specify them in two alternative ways: 
    - Either using multiple keys (`SMB_URL`, `SMB_USERNAME`, `SMB_PASSWORD`; `SMB2_URL`, `SMB2_USERNAME`, `SMB2_PASSWORD`; `SMB3_URL`; `SMB3_USERNAME`, `SMB3_PASSWORD`; etc.)
    - Using an array  in the autopkg prefs (see wiki for details).
- If you require uploading to both a JCDS/CDP plus one or more SMB DPs, set the key `CLOUD_DP` to `True` in your AutoPkg prefs.