### PR TITLE
Correct Correto 11 package name

### DIFF
--- a/AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe.yaml
+++ b/AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe.yaml
@@ -47,7 +47,7 @@ Process:
             user: root
         id: com.amazon.corretto-11.jdk
         options: purge_ds_store
-        pkgname: AmazonCorettoJDK11-%version%
+        pkgname: AmazonCorrettoJDK11-%version%
         scripts: Scripts
         version: "%version%"
 


### PR DESCRIPTION
This recipe is saving the Correto 11 package as `%RECIPE_CACHE_DIR%/AmazonCorettoJDK11-%version%.pkg`

(notice the missing r)

this is breaking our overrides that expect
```
<key>pkg_path</key>
<string>%RECIPE_CACHE_DIR%/AmazonCorettoJDK11-%version%.pkg</string>
```

Autopkg run output
```
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/victor_desouza/src/munki
MunkiImporter: File /Users/victor_desouza/Library/AutoPkg/Cache/local.munki.AmazonCorretto11/AmazonCorrettoJDK11-11.0.19.7.1.pkg does not exist
creating pkginfo for /Users/victor_desouza/Library/AutoPkg/Cache/local.munki.AmazonCorretto11/AmazonCorrettoJDK11-11.0.19.7.1.pkg failed: File /Users/victor_desouza/Library/AutoPkg/Cache/local.munki.AmazonCorretto11/AmazonCorrettoJDK11-11.0.19.7.1.pkg does not exist

Failed.
```

Looking at the Cache folder (note the missing r pkg):
```
04:38 PM victor_desouza:~ $ ls /Users/victor_desouza/Library/AutoPkg/Cache/local.munki.AmazonCorretto11
AmazonCorettoJDK11-11.0.19.7.1.pkg  downloads/                          receipts/
```