### PR TITLE
Add pkginfo size output

### DIFF
--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -579,6 +579,9 @@ class PkgInfoReader(Copier):
             self.env["infodict"] = cataloginfo
             self.env["version"] = cataloginfo["version"]
             self.env["minimum_os_version"] = cataloginfo["minimum_os_version"]
+            self.env["installer_item_size"] = cataloginfo["installer_item_size"]
+            self.env["installed_size"] = cataloginfo["installed_size"]
+            
 
         finally:
             if dmg:

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -582,7 +582,6 @@ class PkgInfoReader(Copier):
             self.env["installer_item_size"] = cataloginfo["installer_item_size"]
             self.env["installed_size"] = cataloginfo["installed_size"]
             
-
         finally:
             if dmg:
                 self.unmount(dmg_path)


### PR DESCRIPTION
Adds additional keys from `cataloginfo` to processor output:
- `installer_item_size`: size of the source pkg sent to the processor
- `installed_size`: size of the pkg contents once installed, as reported by the pkg