### PR TITLE
Add pkginfo size output

### DIFF
--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -55,6 +55,7 @@ class PkgInfoReader(Copier):
             "return the highest version found if multiple packages are found.",
         },
         "minimum_os_version": {"description": "The minimum OS version if supplied."},
+        "installed_size": {"description": "The size of the app when installed (in kilobytes)."},
         "installer_item_size": {"description": "The size of the package (in bytes)."}
     }
 
@@ -512,7 +513,7 @@ class PkgInfoReader(Copier):
         for infoitem in receiptinfo:
             if APLooseVersion(infoitem["version"]) > APLooseVersion(highestpkgversion):
                 highestpkgversion = infoitem["version"]
-            if "installed_size" in infoitem:
+            if "installKBytes" in infoitem:
                 # note this is in KBytes
                 installedsize += infoitem["installed_size"]
 
@@ -536,7 +537,7 @@ class PkgInfoReader(Copier):
         installer_item_size = os.path.getsize(pkgitem)
         cataloginfo["installer_item_size"] = installer_item_size
 
-        if "installed_size" in installerinfo:
+        if "installKBytes" in installerinfo:
             if installerinfo["installed_size"] > 0:
                 cataloginfo["installed_size"] = installerinfo["installed_size"]
         elif installedsize:
@@ -584,6 +585,7 @@ class PkgInfoReader(Copier):
             self.env["version"] = cataloginfo["version"]
             self.env["minimum_os_version"] = cataloginfo["minimum_os_version"]
             self.env["installer_item_size"] = cataloginfo["installer_item_size"]
+            self.env["installed_size"] = cataloginfo["installed_size"]
 
         finally:
             if dmg:

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -513,7 +513,7 @@ class PkgInfoReader(Copier):
         for infoitem in receiptinfo:
             if APLooseVersion(infoitem["version"]) > APLooseVersion(highestpkgversion):
                 highestpkgversion = infoitem["version"]
-            if "installKBytes" in infoitem:
+            if "installed_size" in infoitem:
                 # note this is in KBytes
                 installedsize += infoitem["installed_size"]
 

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -579,6 +579,9 @@ class PkgInfoReader(Copier):
             self.env["infodict"] = cataloginfo
             self.env["version"] = cataloginfo["version"]
             self.env["minimum_os_version"] = cataloginfo["minimum_os_version"]
+            self.env["installer_item_size"] = cataloginfo["installer_item_size"]
+            self.env["installed_size"] = cataloginfo["installed_size"]
+            
 
         finally:
             if dmg:

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -537,9 +537,9 @@ class PkgInfoReader(Copier):
         installer_item_size = os.path.getsize(pkgitem)
         cataloginfo["installer_item_size"] = installer_item_size
 
-        if "installKBytes" in installerinfo:
-            if installerinfo["installed_size"] > 0:
-                cataloginfo["installed_size"] = installerinfo["installed_size"]
+        if "installKBytes" in receiptinfo:
+            if receiptinfo["installKBytes"] > 0:
+                cataloginfo["installed_size"] = receiptinfo["installKBytes"]
         elif installedsize:
             cataloginfo["installed_size"] = installedsize
 

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -55,6 +55,7 @@ class PkgInfoReader(Copier):
             "return the highest version found if multiple packages are found.",
         },
         "minimum_os_version": {"description": "The minimum OS version if supplied."},
+        "installer_item_size": {"description": "The size of the package (in bytes)."},
     }
 
     description = __doc__

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -582,7 +582,6 @@ class PkgInfoReader(Copier):
             self.env["installer_item_size"] = cataloginfo["installer_item_size"]
             self.env["installed_size"] = cataloginfo["installed_size"]
             
-
         finally:
             if dmg:
                 self.unmount(dmg_path)

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -55,8 +55,7 @@ class PkgInfoReader(Copier):
             "return the highest version found if multiple packages are found.",
         },
         "minimum_os_version": {"description": "The minimum OS version if supplied."},
-        "installer_item_size": {"description": "The size of the package (in bytes)."},
-        "installed_size": {"description": "The size of the app when installed (in bytes)."}
+        "installer_item_size": {"description": "The size of the package (in bytes)."}
     }
 
     description = __doc__
@@ -585,8 +584,7 @@ class PkgInfoReader(Copier):
             self.env["version"] = cataloginfo["version"]
             self.env["minimum_os_version"] = cataloginfo["minimum_os_version"]
             self.env["installer_item_size"] = cataloginfo["installer_item_size"]
-            self.env["installed_size"] = cataloginfo["installed_size"]
-            
+
         finally:
             if dmg:
                 self.unmount(dmg_path)

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -532,6 +532,9 @@ class PkgInfoReader(Copier):
             if key in installerinfo:
                 cataloginfo[key] = installerinfo[key]
 
+        installer_item_size = os.path.getsize(pkgitem)
+        cataloginfo["installer_item_size"] = installer_item_size
+
         if "installed_size" in installerinfo:
             if installerinfo["installed_size"] > 0:
                 cataloginfo["installed_size"] = installerinfo["installed_size"]

--- a/CommonProcessors/PkgInfoReader.py
+++ b/CommonProcessors/PkgInfoReader.py
@@ -56,6 +56,7 @@ class PkgInfoReader(Copier):
         },
         "minimum_os_version": {"description": "The minimum OS version if supplied."},
         "installer_item_size": {"description": "The size of the package (in bytes)."},
+        "installed_size": {"description": "The size of the app when installed (in bytes)."}
     }
 
     description = __doc__


### PR DESCRIPTION
- Adds call to `os.path.getsize()` to get `installer_item_size` in bytes
- Adds output and description for `installer_item_size`