### PR TITLE
Fixed Nudge pkg recipe for Nudge_Suite download

### DIFF
--- a/Nudge/Nudge.pkg.recipe.yaml
+++ b/Nudge/Nudge.pkg.recipe.yaml
@@ -1,4 +1,4 @@
-Description: Downloads the latest release of Unison.
+Description: Downloads the latest release of Nudge.
 Identifier: com.github.grahampugh.recipes.pkg.Nudge
 Input:
   NAME: Nudge

--- a/Nudge/Nudge.pkg.recipe.yaml
+++ b/Nudge/Nudge.pkg.recipe.yaml
@@ -19,9 +19,13 @@ Process:
       destination_path: "%RECIPE_CACHE_DIR%/payload"
       pkg_payload_path: "%found_filename%/Payload"
     Processor: PkgPayloadUnpacker
+    
+  - Arguments:
+      pattern: "%RECIPE_CACHE_DIR%/payload/**/Nudge.app/Contents/Info.plist"
+    Processor: FileFinder
 
   - Arguments:
-      input_plist_path: "%RECIPE_CACHE_DIR%/payload/Nudge.app/Contents/Info.plist"
+      input_plist_path: "%found_filename%"
     Processor: Versioner
 
   - Arguments:


### PR DESCRIPTION
Made a change to the Nudge Pkg recipe to allow it to correctly process a pkg file for the Nudge_Suite. The parent download recipe allows for an INPUT variable specifying the type to download alternate pkgs from Github but this pkg recipe fails when using the "_Suite" type. I have added a FileFinder Processor to correct this issue. I believe this issue must have been discovered in the munki recipe "com.github.erikng.munki.Nudge" too so I actually just replicated the solution which was implemented there (link to commit below for reference).

https://github.com/autopkg/erikng-recipes/commit/be5a627361c6ab12a74de6e2b086d261e5276612

I also just fixed up a small typo in the description for this pkg recipe which was referring to the App "Unison" rather than "Nudge".

Have tested this recipe in my own environment both with and without the TYPE input variable and it works as expected in both cases.