### PR TITLE
ChoicesXMLGenerator.py Add regex filter to installer output

### DIFF
--- a/CommonProcessors/ChoicesXMLGenerator.py
+++ b/CommonProcessors/ChoicesXMLGenerator.py
@@ -56,7 +56,7 @@ class ChoicesXMLGenerator(Processor):
         """Invoke the installer showChoicesXML command and return
         the contents"""
         (choices_result, error) = subprocess.Popen(
-            ["/usr/sbin/installer", "-showChoicesXML", "-pkg", choices_pkg_path],
+            ["/usr/sbin/installer", "-showChoicesXML", "-pkg", choices_pkg_path, "-target", "/"],
             stdout=subprocess.PIPE,
         ).communicate()
         if choices_result:

--- a/CommonProcessors/ChoicesXMLGenerator.py
+++ b/CommonProcessors/ChoicesXMLGenerator.py
@@ -23,6 +23,7 @@ import subprocess
 
 from autopkglib import Processor, ProcessorError  # pylint: disable=import-error
 import plistlib
+import re
 
 __all__ = ["ChoicesXMLGenerator"]
 
@@ -54,12 +55,18 @@ class ChoicesXMLGenerator(Processor):
     def output_showchoicesxml(self, choices_pkg_path):
         """Invoke the installer showChoicesXML command and return
         the contents"""
-        (choices_plist, error) = subprocess.Popen(
+        (choices_result, error) = subprocess.Popen(
             ["/usr/sbin/installer", "-showChoicesXML", "-pkg", choices_pkg_path],
             stdout=subprocess.PIPE,
         ).communicate()
-        if choices_plist:
+        if choices_result:
             try:
+                choices_plist = bytearray(
+                    re.search(
+                        r"(?s)<\?xml.*</plist>", choices_result.decode("utf-8")
+                    ).group(),
+                    "utf-8",
+                )
                 choices_list = plistlib.loads(choices_plist)
             except Exception as err:
                 raise ProcessorError(


### PR DESCRIPTION
### Summary (TL;DR)

`installer -showChoicesXML` can potentially output to `stdout` text other than the manifest `plist`, which then causes `ChoicesXMLGenerator.py` to fail. This PR applies a simple regex to the output to only look at the text from `<?xml` to `</plist>` before attempting to parse it as a `plist`.

### Background
While working on a recipe for Avid Sibelius, I discovered that `installer -showChoicesXML` output additional text before the manifest plist. Unfortunately the current pkg is paywalled, and the non-paywalled v7.1.3 does not contain the issue, so instead I will describe my findings.

The output when `installer -showChoicesXML` is run directly on the package was:

```
% installer -showChoicesXML -pkg Install\ Sibelius.pkg
System language detected is: en
Cheking toward es failed
System language detected is: en
Cheking toward pt failed
System language detected is: en
Cheking toward fr failed
System language detected is: en
Checking toward en ok 
System language detected is: en
Cheking toward de failed
System language detected is: en
Cheking toward it failed
System language detected is: en
Cheking toward ja failed
System language detected is: en
Cheking toward zh failed
System language detected is: en
Cheking toward ru failed
System language detected is: en
Cheking toward zh failed
System language detected is: en
Cheking toward ja failed
System language detected is: en
Cheking toward it failed
System language detected is: en
Cheking toward de failed
System language detected is: en
Checking toward en ok 
System language detected is: en
Cheking toward fr failed
System language detected is: en
Cheking toward pt failed
System language detected is: en
Cheking toward es failed
System language detected is: en
Cheking toward es failed
System language detected is: en
Cheking toward pt failed
System language detected is: en
Cheking toward fr failed
System language detected is: en
Checking toward en ok 
System language detected is: en
Cheking toward de failed
System language detected is: en
Cheking toward it failed
System language detected is: en
Cheking toward ja failed
System language detected is: en
Cheking toward zh failed
System language detected is: en
Cheking toward ru failed
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<array>
	<dict>
		<key>childItems</key>
		<array>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceDescription</key>
				<string>Required
Installs Sibelius.</string>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius.app</string>
				<key>choiceIsEnabled</key>
				<false/>
				<key>choiceIsSelected</key>
				<integer>1</integer>
				<key>choiceIsVisible</key>
				<true/>
				<key>choiceSizeInKilobytes</key>
				<integer>933385</integer>
				<key>choiceTitle</key>
				<string>Sibelius</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#Sibelius.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceDescription</key>
				<string>Required
Installs the Avid Application Manager. Application Manager runs as a service in the background, and handles Sibelius' licensing and automatically checks for and downloads updates to Avid software.</string>
				<key>choiceIdentifier</key>
				<string>com.avid.tmp.AppMan.pkg</string>
				<key>choiceIsEnabled</key>
				<false/>
				<key>choiceIsSelected</key>
				<integer>1</integer>
				<key>choiceIsVisible</key>
				<true/>
				<key>choiceSizeInKilobytes</key>
				<integer>247888</integer>
				<key>choiceTitle</key>
				<string>Application Manager</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#AppManager_tmp.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceDescription</key>
				<string>If you are installing the trial version of Sibelius, deselect this option to keep your copy of Sibelius 7.1 installed on this computer.
When uninstalling Sibelius 7.1, it won't remove any of your scores.</string>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius71.uninstall</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>0</integer>
				<key>choiceIsVisible</key>
				<false/>
				<key>choiceSizeInKilobytes</key>
				<integer>1</integer>
				<key>choiceTitle</key>
				<string>Uninstall Sibelius 7.1</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#UninstallSibelius71.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceDescription</key>
				<string>If you are installing the trial version of Sibelius, deselect this option to keep your copy of Sibelius 7.5 installed on this computer.
When uninstalling Sibelius 7.5, it won't remove any of your scores.</string>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius75.uninstall</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>0</integer>
				<key>choiceIsVisible</key>
				<false/>
				<key>choiceSizeInKilobytes</key>
				<integer>1</integer>
				<key>choiceTitle</key>
				<string>Uninstall Sibelius 7.5</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#UninstallSibelius75.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceDescription</key>
				<string>Recommended
Select this option to copy any custom House Styles, Sound Sets, Plug-ins and other settings from Sibelius 7.1 to Sibelius.</string>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius71.save_userdata</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>0</integer>
				<key>choiceIsVisible</key>
				<false/>
				<key>choiceSizeInKilobytes</key>
				<integer>1</integer>
				<key>choiceTitle</key>
				<string>Copy supporting files from Sibelius 7.1</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#SaveUserData71.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceDescription</key>
				<string>Recommended
Select this option to copy any custom House Styles, Sound Sets, Plug-ins and other settings from Sibelius 7.5 to Sibelius.</string>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius75.save_userdata</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>0</integer>
				<key>choiceIsVisible</key>
				<false/>
				<key>choiceSizeInKilobytes</key>
				<integer>1</integer>
				<key>choiceTitle</key>
				<string>Copy supporting files from Sibelius 7.5</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#SaveUserData75.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius.rewire</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>1</integer>
				<key>choiceIsVisible</key>
				<false/>
				<key>choiceSizeInKilobytes</key>
				<integer>1194</integer>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#ReWire.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius.fonts</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>1</integer>
				<key>choiceIsVisible</key>
				<false/>
				<key>choiceSizeInKilobytes</key>
				<integer>1310</integer>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#Fonts.pkg</string>
				</array>
			</dict>
			<dict>
				<key>childItems</key>
				<array>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install English-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.sibelius.englishscores</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>1</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>9990</integer>
						<key>choiceTitle</key>
						<string>English Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#EnglishScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install French-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_fr</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>10240</integer>
						<key>choiceTitle</key>
						<string>French Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#FrenchScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install German-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_de</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>10201</integer>
						<key>choiceTitle</key>
						<string>German Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#GermanScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install Italian-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_it</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>10223</integer>
						<key>choiceTitle</key>
						<string>Italian Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#ItalianScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install Japanese-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_jp</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>10280</integer>
						<key>choiceTitle</key>
						<string>Japanese Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#JapaneseScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install Simplified Chinese-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_zh</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>9990</integer>
						<key>choiceTitle</key>
						<string>Simplified Chinese Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#SimplifiedChineseScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install Spanish-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_es</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>10241</integer>
						<key>choiceTitle</key>
						<string>Spanish Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#SpanishScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install Russian-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_ru</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>9989</integer>
						<key>choiceTitle</key>
						<string>Russian Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#RussianScores.pkg</string>
						</array>
					</dict>
					<dict>
						<key>childItems</key>
						<array/>
						<key>choiceDescription</key>
						<string>Recommended
Select this option to install Brazilian Portuguese-language Sibelius example scores in your Scores folder.</string>
						<key>choiceIdentifier</key>
						<string>com.avid.pkg.scores_pt</string>
						<key>choiceIsEnabled</key>
						<true/>
						<key>choiceIsSelected</key>
						<integer>0</integer>
						<key>choiceIsVisible</key>
						<true/>
						<key>choiceSizeInKilobytes</key>
						<integer>9990</integer>
						<key>choiceTitle</key>
						<string>Brazilian Portuguese Scores</string>
						<key>pathsOfActivePackagesInChoice</key>
						<array>
							<string>file://localhost/Volumes/Sibelius/Install%20Sibelius.pkg#BrazilianPortugueseScores.pkg</string>
						</array>
					</dict>
				</array>
				<key>choiceDescription</key>
				<string>Optional
Select this option to install the Sibelius example scores in all languages in your Scores folder. Expand this option to see other available languages.</string>
				<key>choiceIdentifier</key>
				<string>com.avid.pkg.sibelius.scores</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>-1</integer>
				<key>choiceIsVisible</key>
				<true/>
				<key>choiceSizeInKilobytes</key>
				<integer>0</integer>
				<key>choiceTitle</key>
				<string>Scores</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array/>
			</dict>
		</array>
		<key>choiceIdentifier</key>
		<string>__ROOT_CHOICE_IDENT_installer.title</string>
		<key>choiceIsEnabled</key>
		<true/>
		<key>choiceIsSelected</key>
		<integer>-1</integer>
		<key>choiceIsVisible</key>
		<true/>
		<key>choiceSizeInKilobytes</key>
		<integer>0</integer>
		<key>choiceTitle</key>
		<string>Sibelius</string>
		<key>pathsOfActivePackagesInChoice</key>
		<array/>
	</dict>
</array>
</plist>
```
This led me to finding `test_sys_lang.sh` in the `Scripts` directory when I expanded the pkg (the typo helped locate it):
```
#!/bin/sh

# Copyright 2014 by Avid Technology, Inc. All Rights Reserved

SYSLANG=`defaults read .GlobalPreferences AppleLanguages | tr -d [:space:] | tr -d \" | cut -c2-3`
echo "System language detected is: $SYSLANG"

if [ $1 == "en" ]; then
    if [[ $SYSLANG != "en" && $SYSLANG != "fr" && $SYSLANG != "de" && $SYSLANG != "it" && $SYSLANG != "ja" && $SYSLANG != "zh" && $SYSLANG != "es" && $SYSLANG != "ru"  && $SYSLANG != "pt" ]]; then
        echo "Unsupported language $SYSLANG - defaulting to en"
        exit 0
    fi
fi

if [ $SYSLANG == $1 ]; then
    echo "Checking toward $1 ok "
    exit 0
fi
echo "Cheking toward $1 failed"
exit 1
```
`test_sys_lang.sh` is referenced inside a function in the `<script>` block in the `Distribution` file:
```
function isSystemLang( language ) {
   if ( system.run("test_sys_lang.sh", language) == 0 ) {
      return true;
   } else {
      return false;
   }
}
```
which in turn is called against `start_selected` within many choices e.g.:
```
<choice id="com.avid.pkg.sibelius.englishscores" start_selected="isSystemLang('en')" title="English Scores" description="scores.en.description">
   <pkg-ref id="com.avid.pkg.sibelius.englishscores"/>
</choice>
```

Although I could have dealt with this particular package by commenting out the `echo` lines in `test_sys_lang.sh` before running `ChoicesXMLGenerator.py`, I thought this simple regex solution might be a bit more robust and potentially help some other poor soul dealing with a poorly-written package.