### PR TITLE
Update MendeleyReferenceManager.download.recipe.yaml

### DIFF
--- a/MendeleyReferenceManager/MendeleyReferenceManager.download.recipe.yaml
+++ b/MendeleyReferenceManager/MendeleyReferenceManager.download.recipe.yaml
@@ -19,7 +19,11 @@ Process:
 
   - Processor: EndOfCheckPhase
 
+  - Processor: AppDmgVersioner
+    Arguments:
+      dmg_path: "%pathname%"
+
   - Processor: CodeSignatureVerifier
     Arguments:
-      input_path: "%pathname%/%NAME%.app"
+      input_path: "%pathname%/%app_name%"
       requirement: identifier "com.elsevier.mendeley" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "45K89Y5X9B"


### PR DESCRIPTION
We use %NAME% as a short name of the app and %DISPLAYNAME% as the longer one (with spaces in this case) in downstream recipes so this one breaks on it.  I've suggested adding an AppDmgVersioner processor into this which makes the recipe slightly less fragile if the app name changes (as it detects *.app) and also allows it to run if the %NAME% variable is overridden in downstream recipes.