### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/DataWarrior/DataWarrior.download.recipe.yaml
+++ b/DataWarrior/DataWarrior.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: "2.3"
 
 Input:
   NAME: DataWarrior
-  DOWNLOAD_URL: http://www.openmolecules.org/datawarrior/download.html
+  DOWNLOAD_URL: https://www.openmolecules.org/datawarrior/download.html
 
 Process:
   - Processor: URLTextSearcher

--- a/DataWarrior/DataWarrior.pkg.recipe.yaml
+++ b/DataWarrior/DataWarrior.pkg.recipe.yaml
@@ -6,7 +6,7 @@ MinimumVersion: "2.3"
 
 Input:
   NAME: DataWarrior
-  DOWNLOAD_URL: http://www.openmolecules.org/datawarrior/download.html
+  DOWNLOAD_URL: https://www.openmolecules.org/datawarrior/download.html
 
 Process:
   - Processor: URLTextSearcher

--- a/Parallels/ParallelsDesktop.pkg.recipe.yaml
+++ b/Parallels/ParallelsDesktop.pkg.recipe.yaml
@@ -22,7 +22,7 @@ Process:
   - Processor: URLDownloader
     Arguments:
       filename: pd-autodeploy.zip
-      url: http://download.parallels.com/desktop/tools/pd-autodeploy.zip
+      url: https://download.parallels.com/desktop/tools/pd-autodeploy.zip
 
   - Processor: Unarchiver
     Arguments:

--- a/TeX/BasicTeX.download.recipe.yaml
+++ b/TeX/BasicTeX.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: "2.3"
 
 Input:
   NAME: BasicTeX
-  DOWNLOAD_URL: http://tug.org/cgi-bin/mactex-download/%NAME%.pkg
+  DOWNLOAD_URL: https://tug.org/cgi-bin/mactex-download/%NAME%.pkg
 
 Process:
   - Processor: URLTextSearcher


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!