### PR TITLE
Update parents that reference killahquam-recipes

### DIFF
--- a/Jamf_Package_Upload_Only_Recipes/Slack-pkg-upload.jamf.recipe
+++ b/Jamf_Package_Upload_Only_Recipes/Slack-pkg-upload.jamf.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Recipe automatically generated from com.github.killahquam.jss.slack by JamfRecipeMaker</string>
+	<string>Recipe automatically generated from com.github.killahquam.jss.slack by JamfRecipeMaker, and updated to parent com.github.rtrouton.pkg.SlackUniversal</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.grahampugh-recipes.jamf.Slack-pkg-upload</string>
 	<key>Input</key>
@@ -16,7 +16,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.killahquam.pkg.slack</string>
+	<string>com.github.rtrouton.pkg.SlackUniversal</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Jamf_Package_Upload_Only_Recipes/VisualStudioCode-pkg-upload.jamf.recipe
+++ b/Jamf_Package_Upload_Only_Recipes/VisualStudioCode-pkg-upload.jamf.recipe
@@ -16,7 +16,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.killahquam.pkg.visualstudioscode</string>
+	<string>com.github.amsysuk-recipes.pkg.VisualStudioCode</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Jamf_Recipes/Slack.jamf.recipe
+++ b/Jamf_Recipes/Slack.jamf.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 	<dict>
 		<key>Comment</key>
-		<string>Recipe automatically generated from com.github.killahquam.jss.slack by JamfRecipeMaker</string>
+	<string>Recipe automatically generated from com.github.killahquam.jss.slack by JamfRecipeMaker, and updated to parent com.github.rtrouton.pkg.SlackUniversal</string>
 		<key>Identifier</key>
 		<string>com.github.autopkg.grahampugh-recipes.jamf.Slack</string>
 		<key>Input</key>
@@ -36,7 +36,7 @@
 		<key>MinimumVersion</key>
 		<string>2.3</string>
 		<key>ParentRecipe</key>
-		<string>com.github.killahquam.pkg.slack</string>
+		<string>com.github.rtrouton.pkg.SlackUniversal</string>
 		<key>Process</key>
 		<array>
 			<dict>

--- a/Jamf_Recipes/VisualStudioCode.jamf.recipe
+++ b/Jamf_Recipes/VisualStudioCode.jamf.recipe
@@ -36,7 +36,7 @@
 		<key>MinimumVersion</key>
 		<string>2.3</string>
 		<key>ParentRecipe</key>
-		<string>com.github.killahquam.pkg.visualstudioscode</string>
+		<string>com.github.amsysuk-recipes.pkg.VisualStudioCode</string>
 		<key>Process</key>
 		<array>
 			<dict>

--- a/VisualStudioCode/VisualStudioCode.install.recipe.yaml
+++ b/VisualStudioCode/VisualStudioCode.install.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Installs the latest version of Visual Studio Code.
 Identifier: com.github.grahampugh.install.VisualStudioCode
-ParentRecipe: com.github.killahquam.download.visualstudiocode
+ParentRecipe: com.github.valdore86.download.visualstudiocode
 MinimumVersion: "2.3"
 
 Input:


### PR DESCRIPTION
The recipes in killahquam-recipes have been deprecated and will be removed soon. (See https://github.com/autopkg/killahquam-recipes/issues/28 for details.)

This pull request adjusts the parents for recipes that reference killahquam-recipes. The parents have been changed to actively maintained recipes in other repos.