### PR TITLE
Deprecate JSS recipes

### DIFF
--- a/MunkiToolsCore/MunkiToolsCore.install.recipe.yaml
+++ b/MunkiToolsCore/MunkiToolsCore.install.recipe.yaml
@@ -4,7 +4,7 @@ ParentRecipe: com.github.grahampugh.recipes.pkg.MunkiToolsCore
 MinimumVersion: "2.3"
 
 Input:
-  NAME: JSSImporter
+  NAME: MunkiToolsCore
 
 Process:
   - Processor: Installer

--- a/_Deprecated_Recipes/JSSImporterBeta/JSSImporterBeta.download.recipe.yaml
+++ b/_Deprecated_Recipes/JSSImporterBeta/JSSImporterBeta.download.recipe.yaml
@@ -6,6 +6,10 @@ Input:
   NAME: JSSImporter
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning: JSSImporter is no longer maintained. This recipe is deprecated and will be removed in the future.
+
   - Processor: GitHubReleasesInfoProvider
     Arguments:
       github_repo: jssimporter/JSSImporter

--- a/_Deprecated_Recipes/_JSS_Recipes/Element.jss.recipe.yaml
+++ b/_Deprecated_Recipes/_JSS_Recipes/Element.jss.recipe.yaml
@@ -17,6 +17,10 @@ Input:
   TESTING_GROUP_NAME: Testing
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.
+
   - Processor: com.github.grahampugh.recipes.commonprocessors/VersionRegexGenerator
 
   - Processor: JSSImporter

--- a/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/AdobeCCDAFromConsoleForJamfPro.jss-upload.recipe.yaml
+++ b/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/AdobeCCDAFromConsoleForJamfPro.jss-upload.recipe.yaml
@@ -13,6 +13,10 @@ Input:
   CATEGORY: Productivity
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.
+
   - Processor: JSSImporter
     Arguments:
       category: "%CATEGORY%"

--- a/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/AdobeLicensingToolkit.jss-upload.recipe.yaml
+++ b/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/AdobeLicensingToolkit.jss-upload.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   CATEGORY: Productivity
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.
+
   - Processor: JSSImporter
     Arguments:
       category: "%CATEGORY%"

--- a/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/CotEditor.jss-upload.recipe.yaml
+++ b/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/CotEditor.jss-upload.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   CATEGORY: Apps
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.
+
   - Processor: JSSImporter
     Arguments:
       category: "%CATEGORY%"

--- a/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/FileZilla-stable.jss-upload.recipe.yaml
+++ b/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/FileZilla-stable.jss-upload.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   NAME: FileZilla
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.
+      
   - Arguments:
       category: "%CATEGORY%"
       prod_name: "%NAME%"

--- a/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/MestReNova.jss-upload.recipe.yaml
+++ b/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/MestReNova.jss-upload.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   CATEGORY: Science & Math
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.
+
   - Processor: JSSImporter
     Arguments:
       category: "%CATEGORY%"

--- a/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/Unison.jss-upload.recipe.yaml
+++ b/_Deprecated_Recipes/_JSS_Upload_Only_Recipes/Unison.jss-upload.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   CATEGORY: Tools & Accessories
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.
+
   - Processor: JSSImporter
     Arguments:
       category: "%CATEGORY%"


### PR DESCRIPTION
[JSSImporter](https://github.com/jssimporter/JSSImporter) is no longer maintained. This pull request marks JSS type recipes as deprecated, and urges users to consider switching to equivalent [JamfUploader](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors) recipes.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._