### PR TITLE
Deprecate LibreOffice language pack recipes

### DIFF
--- a/LibreOffice/LibreOfficeLangPack.download.recipe.yaml
+++ b/LibreOffice/LibreOfficeLangPack.download.recipe.yaml
@@ -9,6 +9,10 @@ Input:
   RELEASE: still
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: Consider switching to the LibreOfficeLangPack recipes in the wycomco-recipes repo. This recipe is deprecated and will be removed in the future.
+
   - Processor: com.github.sebtomasi.SharedProcessors/RenameVar
     Arguments:
       input_var: "%pathname%"


### PR DESCRIPTION
The non-functional LibreOffice language pack recipes in this repo are redundant with the functional ones in the wycomo-recipes repo. This PR deprecates these recipes and points users to alternatives.
