### PR TITLE
Fix Folding@Home recipes

### DIFF
--- a/FoldingAtHome/FoldingAtHome.download.recipe.yaml
+++ b/FoldingAtHome/FoldingAtHome.download.recipe.yaml
@@ -8,27 +8,19 @@ Input:
 Process:
   - Processor: URLTextSearcher
     Arguments:
-      re_pattern: (?P<url>https:\/\/download\.foldingathome\.org\/releases\/public\/release\/fah-installer\/osx-10.*fah-installer_(?P<version>.*?)_x86_64\.mpkg\.zip)
-      url: https://download.foldingathome.org
-      request_headers:
-        user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15
+      re_pattern: (?P<urlpath>macos-\d+-universal/release/fah-client_(?P<version>[\d\.]+)_universal\.pkg)
+      url: https://download.foldingathome.org/releases/public/fah-client/meta.json
 
   - Processor: URLDownloader
     Arguments:
-      url: "%url%"
+      url: "https://download.foldingathome.org/releases/public/fah-client/%urlpath%"
 
   - Processor: EndOfCheckPhase
-
-  - Processor: Unarchiver
-    Arguments:
-      archive_path: "%pathname%"
-      destination_path: "%RECIPE_CACHE_DIR%/unzip"
-      purge_destination: true
 
   - Processor: CodeSignatureVerifier
     Arguments:
       expected_authority_names:
-        - "Developer ID Installer: Joseph Coffland (M9MP6KCS4V)"
+        - "Developer ID Installer: Cauldron Development Oy (M9MP6KCS4V)"
         - Developer ID Certification Authority
         - Apple Root CA
-      input_path: "%RECIPE_CACHE_DIR%/unzip/fah-installer_%version%_x86_64.pkg"
+      input_path: "%pathname%"


### PR DESCRIPTION
This PR updates the download method for Folding@Home.

Verbose recipe run output:

```
% autopkg run -vvq 'FoldingAtHome/FoldingAtHome.download.recipe.yaml'
Processing FoldingAtHome/FoldingAtHome.download.recipe.yaml...
WARNING: FoldingAtHome/FoldingAtHome.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<urlpath>macos-\\d+-universal/release/fah-client_(?P<version>[\\d\\.]+)_universal\\.pkg)',
           'url': 'https://download.foldingathome.org/releases/public/fah-client/meta.json'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (urlpath): macos-12-universal/release/fah-client_8.3.18_universal.pkg
URLTextSearcher: Found matching text (version): 8.3.18
URLTextSearcher: Found matching text (match): macos-12-universal/release/fah-client_8.3.18_universal.pkg
{'Output': {'match': 'macos-12-universal/release/fah-client_8.3.18_universal.pkg',
            'urlpath': 'macos-12-universal/release/fah-client_8.3.18_universal.pkg',
            'version': '8.3.18'}}
URLDownloader
{'Input': {'url': 'https://download.foldingathome.org/releases/public/fah-client/macos-12-universal/release/fah-client_8.3.18_universal.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 12 Jul 2024 13:36:16 GMT
URLDownloader: Storing new ETag header: "66913150-69a0d5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FoldingAtHome/downloads/fah-client_8.3.18_universal.pkg
{'Output': {'download_changed': True,
            'etag': '"66913150-69a0d5"',
            'last_modified': 'Fri, 12 Jul 2024 13:36:16 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FoldingAtHome/downloads/fah-client_8.3.18_universal.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FoldingAtHome/downloads/fah-client_8.3.18_universal.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Cauldron '
                                        'Development Oy (M9MP6KCS4V)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FoldingAtHome/downloads/fah-client_8.3.18_universal.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "fah-client_8.3.18_universal.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-07-12 13:27:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Cauldron Development Oy (M9MP6KCS4V)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            41 A2 B4 80 58 1C 32 DE 2A DC 1C 56 C7 3F 15 EA A7 0C 68 9C FB 2E
CodeSignatureVerifier:            7E 58 52 40 F1 3F A6 73 96 3B
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FoldingAtHome/receipts/FoldingAtHome.download.recipe-receipt-20241225-204609.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.FoldingAtHome/downloads/fah-client_8.3.18_universal.pkg
```
