### PR TITLE
Fix BasicTeX download URL and NAME variable issue

### DIFF
--- a/TeX/BasicTeX.download.recipe.yaml
+++ b/TeX/BasicTeX.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: "2.3"
 
 Input:
   NAME: BasicTeX
-  DOWNLOAD_URL: https://tug.org/cgi-bin/mactex-download/BasicTeX.pkg
+  DOWNLOAD_URL: https://mirror.ctan.org/systems/mac/mactex/BasicTeX.pkg
 
 Process:
   - Processor: URLTextSearcher

--- a/TeX/BasicTeX.download.recipe.yaml
+++ b/TeX/BasicTeX.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: "2.3"
 
 Input:
   NAME: BasicTeX
-  DOWNLOAD_URL: https://tug.org/cgi-bin/mactex-download/%NAME%.pkg
+  DOWNLOAD_URL: https://tug.org/cgi-bin/mactex-download/BasicTeX.pkg
 
 Process:
   - Processor: URLTextSearcher


### PR DESCRIPTION
This PR fixes a situation in which an admin might override the NAME input variable and unintentionally break the recipe's ability to download the software. Since NAME can be customized, NAME should be avoided whenever it's needed for recipe functionality, as in URLs and file paths.

I've also updated the download URL for BasicTeX.
