### PR TITLE
Deprecate FileZilla recipes

### DIFF
--- a/FileZilla/FileZilla-stable.download.recipe.yaml
+++ b/FileZilla/FileZilla-stable.download.recipe.yaml
@@ -8,6 +8,10 @@ Input:
 
 Process:
   - Arguments:
+      warning_message: Consider switching to the FreeFileSync recipes in the keeleysam-recipes repo. This recipe is deprecated and will be removed in the future.
+    Processor: DeprecationWarning
+
+  - Arguments:
       re_pattern: <p>The latest stable version of FileZilla Client is (?P<dl_version>.*)<\/p>
       url: "%SEARCH_URL%"
       request_headers:


### PR DESCRIPTION
This PR deprecates the FileZilla recipes in this repo, which are not sufficiently distinct from the ones in keeleysam-recipes to merit the extra maintenance effort. The included deprecation message points users to keeleysam-recipes for alternatives.
