### PR TITLE
Update LogitechPresentation.download.recipe.yaml

### DIFF
--- a/LogitechPresentation/LogitechPresentation.download.recipe.yaml
+++ b/LogitechPresentation/LogitechPresentation.download.recipe.yaml
@@ -8,8 +8,8 @@ Input:
 Process:
   - Processor: URLTextSearcher
     Arguments:
-      re_pattern: macOS.*?(https://download01\.logi\.com/web/ftp/pub/techsupport/presentation/LogiPresentation_.*?\.dmg)\\\"
-      url: https://support.logi.com/api/v2/help_center/en-gb/articles.json?label_names=webcontent=productdownload,webproduct=f7f7f812-7db0-11e9-b911-cb2c3611cd40
+      re_pattern: href=\\\"(https://download01\.logi\.com/web/ftp/pub/techsupport/presentation/LogiPresentation_[0-9.]+\.dmg)\\\"
+      url: https://support.logi.com/api/v2/help_center/en-gb/articles.json?label_names=webcontent=productdownload,webproduct=ea27496d-7db0-11e9-aa7f-7386a59f7740
 
   - Processor: URLDownloader
     Arguments:


### PR DESCRIPTION
Hi, @grahampugh 

The LogitechPresentation recipe is currently failing with 
```
Processor: URLTextSearcher: Error: No match found on URL: https://support.logi.com/api/v2/help_center/en-gb/articles.json?label_names=webcontent=productdownload,webproduct=f7f7f812-7db0-11e9-b911-cb2c3611cd40
```

This PR takes the updated search url and regex from https://github.com/autopkg/grahampugh-recipes/issues/148 

Output from a successful -v run
```
autopkg run -v LogitechPresentation.download.recipe.yaml
**load_recipe time: 0.0031582500087097287
Processing LogitechPresentation.download.recipe.yaml...
WARNING: LogitechPresentation.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://download01.logi.com/web/ftp/pub/techsupport/presentation/LogiPresentation_2.10.276.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 26 Sep 2024 11:40:04 GMT
URLDownloader: Storing new ETag header: "9bc8dc3a3757fac0617e0adffcb56244"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_2.10.276.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_2.10.276.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.aPTP2s/LogiPresentation Installer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.aPTP2s/LogiPresentation Installer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.aPTP2s/LogiPresentation Installer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/receipts/LogitechPresentation.download.recipe-receipt-20250121-155739.plist

The following new items were downloaded:
    Download Path                                                                                                                                 
    -------------                                                                                                                                 
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.grahampugh.recipes.download.LogitechPresentation/downloads/LogiPresentation_2.10.276.dmg
```

Worth also noting that Logitech Presentation looks to be deprecated in favour of Logi Options+ and will likely break again at future date. 

https://support.logi.com/hc/en-au/articles/360025141634-Logitech-Presentation

> Important Notice: Logitech Presentation devices are now supported by [Logi Options+](https://www.logitech.com/software/logi-options-plus.html) for a better experience. We highly recommend using [Logi Options+](https://www.logitech.com/software/logi-options-plus.html) with your presentation remotes. We are here to assist you during this transition.
