### PR TITLE
Update IconGenerator.py

### DIFF
--- a/CommonProcessors/IconGenerator.py
+++ b/CommonProcessors/IconGenerator.py
@@ -21,8 +21,8 @@ IconGenerator
 This is a processor for AutoPkg, adapted from AppIconExtractor by Matthew Warren:
 https://github.com/autopkg/haircut-recipes/blob/master/Processors/AppIconExtractor.py
 
-Important! You *must* install the Pillow library to AutoPkg's Python framework.
-You can do this by running:
+Important! Requires the Pillow library to be installed. If it is not found, the
+processor will attempt to install it using the following command:
 
 /usr/local/autopkg/python -m pip install --upgrade Pillow
 """
@@ -39,12 +39,12 @@ from autopkglib.DmgMounter import DmgMounter  # pylint: disable=import-error
 
 try:
     from PIL import Image
-except (ImportError, ModuleNotFoundError) as ex:
-    raise ProcessorError(
-        "The Pillow library is required, but was not found. "
-        "Please run the following command to install the library: "
-        "/usr/local/autopkg/python -m pip install --upgrade Pillow"
-    ) from ex
+except (ImportError, ModuleNotFoundError):
+    import subprocess
+    import sys
+    print("Pillow library not found. Installing...")
+    subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", "Pillow"], check=True)
+    from PIL import Image
 
 __all__ = ["IconGenerator"]
 


### PR DESCRIPTION
Please feel free to reject if too presumptuous. This will install Pillow automatically if not found, rather than raise a ProcessorError. :-)

```
% autopkg run -vv /Users/neilmartin/GitHub/neilmartin83-recipes/JamfTest.jamf.recipe.yaml
Processing /Users/neilmartin/GitHub/neilmartin83-recipes/JamfTest.jamf.recipe.yaml...
WARNING: /Users/neilmartin/GitHub/neilmartin83-recipes/JamfTest.jamf.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Pillow library not found. Installing...
Defaulting to user installation because normal site-packages is not writeable
Collecting Pillow
  Using cached pillow-11.1.0-cp310-cp310-macosx_10_10_x86_64.whl (3.2 MB)
Installing collected packages: Pillow
Successfully installed Pillow-11.1.0
WARNING: You are using pip version 22.0.4; however, version 25.0.1 is available.
You should consider upgrading via the '/usr/local/autopkg/python -m pip install --upgrade pip' command.
com.github.grahampugh.recipes.commonprocessors/IconGenerator
{'Input': {'composite_install_path': '/Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/Microsoft '
                                     'Word-install.png',
           'composite_uninstall_path': '/Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/Microsoft '
                                       'Word-uninstall.png',
           'composite_update_path': '/Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/Microsoft '
                                    'Word-update.png',
           'source_app': '/Applications/Microsoft Word.app'}}
{'Output': {'app_icon_path': '/Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/Microsoft '
                             'Word.png',
            'install_icon_path': '/Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/Microsoft '
                                 'Word-install.png',
            'uninstall_icon_path': '/Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/Microsoft '
                                   'Word-uninstall.png',
            'update_icon_path': '/Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/Microsoft '
                                'Word-update.png'}}
Receipt written to /Users/neilmartin/Library/AutoPkg/Cache/com.github.neilmartin83.Jamf/receipts/JamfTest.jamf.recipe-receipt-20250306-192502.plist

Nothing downloaded, packaged or imported.
```