### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/EndNoteUpdates/EndNoteUpdates.download.recipe.yaml
+++ b/EndNoteUpdates/EndNoteUpdates.download.recipe.yaml
@@ -12,7 +12,7 @@ Process:
   - Processor: URLTextSearcher
     Arguments:
       re_pattern: (/updates/%INT_VERSION%.0/EndNote%MAJOR_VERSION%[0-9]*UpdateInstaller.zip)
-      url: http://download.endnote.com/updates/%INT_VERSION%.0/EN%INT_VERSION%MacUpdates.xml
+      url: https://download.endnote.com/updates/%INT_VERSION%.0/EN%INT_VERSION%MacUpdates.xml
 
   - Processor: URLDownloader
     Arguments:
@@ -35,4 +35,4 @@ Process:
   - Processor: URLTextSearcher
     Arguments:
       re_pattern: (updateTo\>(?P<version>%INT_VERSION%.*?)\<\/updateTo)
-      url: http://download.endnote.com/updates/%INT_VERSION%.0/EN%INT_VERSION%MacUpdates.xml
+      url: https://download.endnote.com/updates/%INT_VERSION%.0/EN%INT_VERSION%MacUpdates.xml

--- a/TeX/BasicTeX.download.recipe.yaml
+++ b/TeX/BasicTeX.download.recipe.yaml
@@ -10,7 +10,7 @@ Process:
   - Processor: URLTextSearcher
     Arguments:
       re_pattern: The full MacTeX-(?P<version>.*) install
-      url: http://www.tug.org/mactex/morepackages.html
+      url: https://www.tug.org/mactex/morepackages.html
 
   - Processor: URLDownloader
     Arguments:


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._