### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AdobeLicensingToolkit/AdobeLicensingToolkit.pkg.recipe.yaml
+++ b/AdobeLicensingToolkit/AdobeLicensingToolkit.pkg.recipe.yaml
@@ -42,7 +42,6 @@ Process:
             path: Library/Management/Adobe
             user: root
         id: com.adobe.adobe-licensing-toolkit
-        options: purge_ds_store
         pkgname: adobe-licensing-toolkit
         version: "1.0"
 

--- a/AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe.yaml
+++ b/AmazonCorrettoJDK/AmazonCorrettoJDK11.pkg.recipe.yaml
@@ -46,7 +46,6 @@ Process:
             path: Library/Java/JavaVirtualMachines
             user: root
         id: com.amazon.corretto-11.jdk
-        options: purge_ds_store
         pkgname: AmazonCorrettoJDK11-%version%
         scripts: Scripts
         version: "%version%"

--- a/AmazonCorrettoJDK/AmazonCorrettoJDK8.pkg.recipe.yaml
+++ b/AmazonCorrettoJDK/AmazonCorrettoJDK8.pkg.recipe.yaml
@@ -46,7 +46,6 @@ Process:
             path: Library/Java/JavaVirtualMachines
             user: root
         id: com.amazon.corretto-8.jdk
-        options: purge_ds_store
         pkgname: AmazonCorettoJDK8-%version%
         scripts: Scripts
         version: "%version%"

--- a/EclipseTemurin/EclipseTemurin11.pkg.recipe.yaml
+++ b/EclipseTemurin/EclipseTemurin11.pkg.recipe.yaml
@@ -70,7 +70,6 @@ Process:
             path: Library/Java/JavaVirtualMachines
             user: root
         id: "net.temurin-%FEATURE_VERSION%-%ARCH%-%JVM_IMPLEMENTATION%.%IMAGE_TYPE%"
-        options: purge_ds_store
         pkgname: "EclipseTemurin_%FEATURE_VERSION%_%IMAGE_TYPE%_%ARCH%_%JVM_IMPLEMENTATION%-%version%"
         version: "%version%"
 

--- a/EclipseTemurin/EclipseTemurin8.pkg.recipe.yaml
+++ b/EclipseTemurin/EclipseTemurin8.pkg.recipe.yaml
@@ -71,7 +71,6 @@ Process:
             path: Library/Java/JavaVirtualMachines
             user: root
         id: "net.temurin-%FEATURE_VERSION%-%ARCH%-%JVM_IMPLEMENTATION%.%IMAGE_TYPE%"
-        options: purge_ds_store
         pkgname: "EclipseTemurin_%FEATURE_VERSION%_%IMAGE_TYPE%_%ARCH%_%JVM_IMPLEMENTATION%-%version%"
         version: "%version%"
 

--- a/EndNoteUpdates/EndNoteUpdates.pkg.recipe.yaml
+++ b/EndNoteUpdates/EndNoteUpdates.pkg.recipe.yaml
@@ -110,7 +110,6 @@ Process:
     Arguments:
       pkg_request:
         id: com.endnote.EndNote%MAJOR_VERSION%
-        options: purge_ds_store
         pkgname: "%NAME%%MAJOR_VERSION%-updater-%version%"
         pkgroot: pkgroot
         scripts: Scripts

--- a/GIMP/GIMP.pkg.recipe.yaml
+++ b/GIMP/GIMP.pkg.recipe.yaml
@@ -34,6 +34,5 @@ Process:
             path: Applications
             user: root
         id: org.gimp.GIMP
-        options: purge_ds_store
         pkgdir: "%RECIPE_CACHE_DIR%"
       pkgname: "%NAME%-%version%"

--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe.yaml
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe.yaml
@@ -43,6 +43,5 @@ Process:
             path: Applications
             user: root
         id: org.libreoffice.langpack-%LANGUAGE_CODE%
-        options: purge_ds_store
         pkgdir: "%RECIPE_CACHE_DIR%"
       pkgname: "%NAME%_%LANGUAGE_CODE%-%version%"

--- a/LogitechGHUB/LogitechGHUB.pkg.recipe.yaml
+++ b/LogitechGHUB/LogitechGHUB.pkg.recipe.yaml
@@ -54,7 +54,6 @@ Process:
       pkg_request:
         chown: []
         id: com.logi.ghub
-        options: purge_ds_store
         pkgdir: "%RECIPE_CACHE_DIR%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgtype: flat

--- a/LogitechPresentation/LogitechPresentation.pkg.recipe.yaml
+++ b/LogitechPresentation/LogitechPresentation.pkg.recipe.yaml
@@ -96,7 +96,6 @@ Process:
       pkg_request:
         chown: []
         id: com.logitech.logipresentation.pkg
-        options: purge_ds_store
         pkgdir: "%RECIPE_CACHE_DIR%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgtype: flat

--- a/MestReNova/MestReNova.pkg.recipe.yaml
+++ b/MestReNova/MestReNova.pkg.recipe.yaml
@@ -24,7 +24,6 @@ Process:
       pkg_request:
         chown: []
         id: com.mestrelabs.mnova.pkg
-        options: purge_ds_store
         pkgdir: "%RECIPE_CACHE_DIR%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgtype: flat

--- a/TeX/TeXShop.pkg.recipe.yaml
+++ b/TeX/TeXShop.pkg.recipe.yaml
@@ -37,6 +37,5 @@ Process:
             path: Applications/TeX
             user: root
         id: edu.uoregon.TeXShop
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         version: "%version%"


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._