### PR TITLE
Fix DisplayLinkLoginScreenExtension pkg recipe

### DIFF
--- a/DisplayLink/DisplayLinkLoginScreenExtension.download.recipe.yaml
+++ b/DisplayLink/DisplayLinkLoginScreenExtension.download.recipe.yaml
@@ -6,6 +6,10 @@ Input:
   NAME: DisplayLink Login Screen Extension
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: Consider switching to the DisplayLinkLoginScreenExtension recipes in the peetinc-recipes repo. This recipe is deprecated and will be removed in the future.
+
   - Processor: URLDownloader
     Arguments:
       url: "https://www.displaylink.com/downloads/macos_extension"

--- a/DisplayLink/DisplayLinkLoginScreenExtension.pkg.recipe.yaml
+++ b/DisplayLink/DisplayLinkLoginScreenExtension.pkg.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Downloads the latest version of the DisplayLink Login Screen Extension and creates a package containing the script. The expectation is that this would be used with a postinstall script containing the parameters required to use this script for upgrading or reinstalling macOS on clients.
 Identifier: com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension
-ParentRecipe: com.github.grahampugh.recipes.download.DisplayLinkLoginScreenExtension
+ParentRecipe: com.github.peetinc.download.DisplayLinkLoginScreenExtension
 MinimumVersion: "2.3"
 
 Input:
@@ -9,7 +9,7 @@ Input:
 Process:
   - Processor: FlatPkgUnpacker
     Arguments:
-      flat_pkg_path: "%pathname%/*.pkg"
+      flat_pkg_path: "%pathname%"
       destination_path: "%RECIPE_CACHE_DIR%/unpack"
       purge_destination: true
 
@@ -31,7 +31,7 @@ Process:
   - Processor: PkgCopier
     Arguments:
       pkg_path: "%RECIPE_CACHE_DIR%/DisplayLinkLoginScreenExtension-%version%.pkg"
-      source_pkg: "%pathname%/*.pkg"
+      source_pkg: "%pathname%"
 
   - Processor: PathDeleter
     Arguments:


### PR DESCRIPTION
The DisplayLinkLoginScreenExtension recipes in this repo were treating the download as a pkg inside a dmg, when the most recent version provides a regular pkg.

This PR alters the pkg for this change, and uses the working download recipe in peetinc-recipes as the parent.

Pkg recipe verbose output:

```
% autopkg run -vvq 'grahampugh-recipes/DisplayLink/DisplayLinkLoginScreenExtension.pkg.recipe.yaml'
Processing grahampugh-recipes/DisplayLink/DisplayLinkLoginScreenExtension.pkg.recipe.yaml...
WARNING: grahampugh-recipes/DisplayLink/DisplayLinkLoginScreenExtension.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'DisplayLink Login Screen Extension.pkg',
           'url': 'https://www.displaylink.com/downloads/macos_extension'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/downloads/DisplayLink Login Screen Extension.pkg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/downloads/DisplayLink '
                        'Login Screen Extension.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: DisplayLink '
                                        'Corp (73YQY62QM3)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/downloads/DisplayLink '
                         'Login Screen Extension.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "DisplayLink Login Screen Extension.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-09-11 21:09:50 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: DisplayLink Corp (73YQY62QM3)
CodeSignatureVerifier:        Expires: 2027-12-17 08:30:26 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            5A F6 23 27 40 D8 10 8B 72 1A C8 D1 7B 41 3D 10 94 90 53 8F 36 26 
CodeSignatureVerifier:            19 B2 E4 DC A5 20 7B C2 DD 10
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/downloads/DisplayLink '
                            'Login Screen Extension.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: No value supplied for skip_payload, setting default value of: False
FlatPkgUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/downloads/DisplayLink Login Screen Extension.pkg to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/unpack/LoginScreenExt.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/unpack/LoginScreenExt.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/payload
{'Output': {}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/payload/com.displaylink.loginscreen.plist',
           'plist_keys': {'CFBundleVersion': 'version'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/payload/com.displaylink.loginscreen.plist
PlistReader: Assigning value of '17' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '17'}}}
com.github.homebysix.VersionSplitter/VersionSplitter
{'Input': {'version': '17'}}
VersionSplitter: Split version: 17
{'Output': {'version': '17'}}
PkgCopier
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/DisplayLinkLoginScreenExtension-17.pkg',
           'source_pkg': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/downloads/DisplayLink '
                         'Login Screen Extension.pkg'}}
PkgCopier: Copied ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/downloads/DisplayLink Login Screen Extension.pkg to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/DisplayLinkLoginScreenExtension-17.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/DisplayLinkLoginScreenExtension-17.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/DisplayLinkLoginScreenExtension-17.pkg'}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/unpack',
                         '~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/payload']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/unpack
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/payload
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/receipts/DisplayLinkLoginScreenExtension.pkg.recipe-receipt-20251109-102726.plist

The following packages were copied:
    Pkg Path                                                                                                                                      
    --------                                                                                                                                      
    ~/Library/AutoPkg/Cache/com.github.grahampugh.recipes.pkg.DisplayLinkLoginScreenExtension/DisplayLinkLoginScreenExtension-17.pkg
```