### PR TITLE
Update code signature requirement for KNIME

### DIFF
--- a/KNIME/KNIME.download.recipe.yaml
+++ b/KNIME/KNIME.download.recipe.yaml
@@ -17,7 +17,7 @@ Process:
   - Processor: CodeSignatureVerifier
     Arguments:
       input_path: "%pathname%/KNIME*.app"
-      requirement: identifier "org.knime.product" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = V7WZJX2HS9
+      requirement: identifier "org.knime.desktop.product" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = V7WZJX2HS9
 
   - Processor: Copier
     Arguments:


### PR DESCRIPTION
Verbose recipe output after the fix:

```
% autopkg run -vvq 'grahampugh-recipes/KNIME/KNIME.download.recipe.yaml'
Processing grahampugh-recipes/KNIME/KNIME.download.recipe.yaml...
WARNING: grahampugh-recipes/KNIME/KNIME.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'KNIME.dmg',
           'url': 'https://download.knime.org/analytics-platform/macosx/knime-latest-app.macosx.cocoa.x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.dmg/KNIME*.app',
           'requirement': 'identifier "org.knime.desktop.product" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'V7WZJX2HS9'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.seEwuV/KNIME 5.5.2.app' matched from globbed '/private/tmp/dmg.seEwuV/KNIME*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.seEwuV/KNIME 5.5.2.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.seEwuV/KNIME 5.5.2.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.seEwuV/KNIME 5.5.2.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.dmg/KNIME*.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.dmg, dmg: .dmg/, dmg_source_path: KNIME*.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.dmg
Copier: Using path '/private/tmp/dmg.Gvzjfe/KNIME 5.5.2.app' matched from globbed '/private/tmp/dmg.Gvzjfe/KNIME*.app'.
Copier: Copied /private/tmp/dmg.Gvzjfe/KNIME 5.5.2.app to ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.app
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 5.5.2 in file ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.app/Contents/Info.plist
{'Output': {'version': '5.5.2'}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.app']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/downloads/KNIME.app
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahampugh.download.KNIME/receipts/KNIME.download.recipe-receipt-20251109-131807.plist

Nothing downloaded, packaged or imported.
```