### PR TITLE
SeqMonk - downloads now hosted on github

### DIFF
--- a/SeqMonk/SeqMonk.download.recipe.yaml
+++ b/SeqMonk/SeqMonk.download.recipe.yaml
@@ -8,13 +8,13 @@ Input:
 Process:
   - Processor: URLTextSearcher
     Arguments:
-      re_pattern: (?P<match>seqmonk/seqmonk_v(?P<version>.*?)_osx64\.dmg)
+      re_pattern: (?P<match>releases/download/v(.*?)/seqmonk_v(?P<version>.*?)_osx64\.dmg)
       url: https://www.bioinformatics.babraham.ac.uk/projects/download.html
       request_headers:
         user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15
 
   - Processor: URLDownloader
     Arguments:
-      url: https://www.bioinformatics.babraham.ac.uk/projects/%match%
+      url: https://github.com/s-andrews/SeqMonk/%match%
 
   - Processor: EndOfCheckPhase


### PR DESCRIPTION
Seqmonk now seems to be hosted at github ; this changed download recipe seems to produce a valid version and the expected .dmg file. 