### PR TITLE
Rename processor for monolithic profile conversion

### DIFF
--- a/Jamf_Helper_Recipes/ConvertMonolithicProfile.jamf.recipe.yaml
+++ b/Jamf_Helper_Recipes/ConvertMonolithicProfile.jamf.recipe.yaml
@@ -15,7 +15,7 @@ Process:
       object_type: os_x_configuration_profile
       object_name: "%NAME%"
 
-  - Processor: com.github.grahampugh.recipes.commonprocessors/MonolithicProfileConverter
+  - Processor: com.github.grahampugh.recipes.commonprocessors/MonolithicProfileDisssector
     Arguments:
       mobileconfig_path: "%payload_file_path%"
       output_directory: /Users/Shared/Jamf/JamfUploader


### PR DESCRIPTION
Should fix:

<img width="742" height="253" alt="image" src="https://github.com/user-attachments/assets/3202ff25-1bd6-446d-ad13-f3fc5acdcbad" />
