### PR TITLE
Add Jamf CLI recipes and example configurations

### DIFF
--- a/JamfCLI-Recipes/JamfPro-CreateCategory.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-CreateCategory.jamfclirunner.recipe.yaml
@@ -1,0 +1,27 @@
+Description: |
+  Creates or updates a category in Jamf Pro. The category can be supplied either
+  as a JSON/YAML file path (FROM_FILE) or inline via the 'data' key. When using
+  'data', provide 'name' and optionally 'priority'; FROM_FILE takes precedence if
+  both are set. Use SCAFFOLD to print an example template without making changes.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProCreateCategory
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  CATEGORY: ""
+  FROM_FILE: ""
+  CONFIRM: "false"
+  PRIORITY: "10"
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: categories
+      action: apply
+      profile: "%PROFILE%"
+      from_file: "%FROM_FILE%"
+      confirm: "%CONFIRM%"
+      data:
+        name: "%CATEGORY%"
+        priority: "%PRIORITY%"

--- a/JamfCLI-Recipes/JamfPro-DeletePolicyByID.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-DeletePolicyByID.jamfclirunner.recipe.yaml
@@ -1,0 +1,22 @@
+Description: >
+  Deletes a policy from a Jamf Pro instance by ID or name. Set POLICY_ID to
+  the numeric ID or exact name of the policy to remove. By default DRY_RUN is
+  true so no changes are made; set it to false to perform the deletion.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProDeletePolicyByID
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  POLICY_ID: ""
+  DRY_RUN: "true"
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: classic-policies
+      action: delete
+      identifier: "%POLICY_ID%"
+      profile: "%PROFILE%"
+      confirm: "true"
+      dry_run: "%DRY_RUN%"

--- a/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
@@ -7,6 +7,7 @@ Input:
   NAME: Carbon Copy Cloner
   POLICY_NAME: "Install Latest %NAME%"
   POLICY_TEMPLATE: JamfPolicyTemplate.xml
+  POLICY_RUN_COMMAND: ""
   USE_FOR_SELF_SERVICE: "true"
   INSTALL_BUTTON_TEXT: Install
   REINSTALL_BUTTON_TEXT: Reinstall
@@ -17,6 +18,11 @@ Input:
   REPLACE_PKG: "False"
 
 Process:
+  - Processor: com.github.grahampugh.recipes.commonprocessors/IconGenerator
+    Arguments:
+      source_app: "%pkgroot%/Applications/Carbon Copy Cloner.app"
+      composite_uninstall_path: "%RECIPE_CACHE_DIR%/%NAME%-uninstall.png"
+
   - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
     Arguments:
       type: pro
@@ -71,14 +77,14 @@ Process:
         criteria:
           - name: Application Title
             priority: 0
-            operator: is
+            searchType: is
             value: "%NAME%.app"
-            and_or: "and"
+            andOr: "and"
           - name: Application Version
             priority: 1
-            operator: is not
+            searchType: is not
             value: "%version%"
-            and_or: "and"
+            andOr: "and"
       output_vars:
         installed_group_id: id
         installed_group_name: name
@@ -86,7 +92,20 @@ Process:
   - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
     Arguments:
       type: pro
+      endpoint: icons
+      action: upload
+      file: "%app_icon_path%"
+      confirm: "false"
+      output_vars:
+        app_icon_id: id
+        app_icon_name: name
+        app_icon_url: url
+
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
       endpoint: classic-policies
       action: apply
+      file: ""
       from_file: JamfPro-Policy-InstallPackage.xml
       confirm: "true"

--- a/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
@@ -7,13 +7,14 @@ Input:
   NAME: Carbon Copy Cloner
   POLICY_NAME: "Install Latest %NAME%"
   POLICY_TEMPLATE: JamfPolicyTemplate.xml
-  TESTING_GROUP_NAME: Testing
+  USE_FOR_SELF_SERVICE: "true"
+  INSTALL_BUTTON_TEXT: "Install"
+  REINSTALL_BUTTON_TEXT: "Reinstall"
   SELF_SERVICE_DESCRIPTION: Powerful disk cloning and backup utility.
-  UPDATE_PREDICATE: pkg_uploaded == False
   SELF_SERVICE_DISPLAY_NAME: "Install Latest %NAME%"
   GROUP_NAME: Carbon Copy Cloner-update-smart
-  GROUP_TEMPLATE: JamfSmartGroupTemplate.xml
   SELF_SERVICE_ICON: "%NAME%.png"
+  REPLACE_PKG: "False"
 
 Process:
   - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
@@ -49,25 +50,43 @@ Process:
       endpoint: packages
       action: apply
       from_file: JamfPro-Package.json
-      confirm: "true"
-      name: "%PKG_NAME%"
+      confirm: "%REPLACE_PKG%"
       pkg_info: Package uploaded using JamfCLIRunner
-      pkg_priority: "10"
       pkg_notes: Package uploaded using JamfCLIRunner
+      pkg_priority: "10"
 
   - Processor: StopProcessingIf
     Arguments:
-      predicate: "FALSEPREDICATE"
+      predicate: "object_updated == False"
 
-  # - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
-  #   Arguments:
-  #     computergroup_name: "%GROUP_NAME%"
-  #     computergroup_template: "%GROUP_TEMPLATE%"
-  #     replace_group: True
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: smart-computer-groups
+      action: apply
+      confirm: "true"
+      data:
+        name: "%GROUP_NAME%"
+        description: Computers with outdated %NAME% package
+        criteria:
+          - name: Application Title
+            priority: 0
+            operator: is
+            value: "%NAME%.app"
+            and_or: "and"
+          - name: Application Version
+            priority: 1
+            operator: is not
+            value: "%version%"
+            and_or: "and"
+      output_vars:
+        installed_group_id: id
+        installed_group_name: name
 
-  # - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
-  #   Arguments:
-  #     replace_policy: True
-  #     policy_template: "%POLICY_TEMPLATE%"
-  #     icon: "%SELF_SERVICE_ICON%"
-  #     policy_name: "%POLICY_NAME%"
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: classic-policies
+      action: apply
+      from_file: JamfPro-Policy-InstallPackage.xml
+      confirm: "true"

--- a/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
@@ -8,8 +8,8 @@ Input:
   POLICY_NAME: "Install Latest %NAME%"
   POLICY_TEMPLATE: JamfPolicyTemplate.xml
   USE_FOR_SELF_SERVICE: "true"
-  INSTALL_BUTTON_TEXT: "Install"
-  REINSTALL_BUTTON_TEXT: "Reinstall"
+  INSTALL_BUTTON_TEXT: Install
+  REINSTALL_BUTTON_TEXT: Reinstall
   SELF_SERVICE_DESCRIPTION: Powerful disk cloning and backup utility.
   SELF_SERVICE_DISPLAY_NAME: "Install Latest %NAME%"
   GROUP_NAME: Carbon Copy Cloner-update-smart

--- a/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-DeployPackage-CarbonCopyCloner.jamfclirunner.recipe.yaml
@@ -1,0 +1,73 @@
+Comment: Recipe automatically generated from com.github.jss-recipes.jss.CarbonCopyCloner by JamfRecipeMaker
+Identifier: com.github.autopkg.grahampugh-recipes.jamfcli.JamfProDeployPackageCarbonCopyCloner
+ParentRecipe: com.github.keeleysam.recipes.pkg.CarbonCopyCloner
+MinimumVersion: "2.3"
+
+Input:
+  NAME: Carbon Copy Cloner
+  POLICY_NAME: "Install Latest %NAME%"
+  POLICY_TEMPLATE: JamfPolicyTemplate.xml
+  TESTING_GROUP_NAME: Testing
+  SELF_SERVICE_DESCRIPTION: Powerful disk cloning and backup utility.
+  UPDATE_PREDICATE: pkg_uploaded == False
+  SELF_SERVICE_DISPLAY_NAME: "Install Latest %NAME%"
+  GROUP_NAME: Carbon Copy Cloner-update-smart
+  GROUP_TEMPLATE: JamfSmartGroupTemplate.xml
+  SELF_SERVICE_ICON: "%NAME%.png"
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: categories
+      action: apply
+      profile: "%PROFILE%"
+      confirm: "true"
+      data:
+        name: Utility
+        priority: 10
+      output_vars:
+        pkg_category_id: id
+        pkg_category_name: name
+
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: categories
+      action: apply
+      confirm: "true"
+      data:
+        name: Testing
+        priority: 10
+      output_vars:
+        policy_category_id: id
+        policy_category_name: name
+
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: packages
+      action: apply
+      from_file: JamfPro-Package.json
+      confirm: "true"
+      name: "%PKG_NAME%"
+      pkg_info: Package uploaded using JamfCLIRunner
+      pkg_priority: "10"
+      pkg_notes: Package uploaded using JamfCLIRunner
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: "FALSEPREDICATE"
+
+  # - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+  #   Arguments:
+  #     computergroup_name: "%GROUP_NAME%"
+  #     computergroup_template: "%GROUP_TEMPLATE%"
+  #     replace_group: True
+
+  # - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+  #   Arguments:
+  #     replace_policy: True
+  #     policy_template: "%POLICY_TEMPLATE%"
+  #     icon: "%SELF_SERVICE_ICON%"
+  #     policy_name: "%POLICY_NAME%"

--- a/JamfCLI-Recipes/JamfPro-ExportComputers.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-ExportComputers.jamfclirunner.recipe.yaml
@@ -1,0 +1,19 @@
+Description: >
+  Exports the full computer inventory from a Jamf Pro instance to a JSON file.
+  The output file is written to RECIPE_CACHE_DIR unless OUT_FILE is overridden.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProExportComputers
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  OUT_FILE: "%RECIPE_CACHE_DIR%/computers.json"
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: computers
+      action: list
+      profile: "%PROFILE%"
+      output: json
+      out_file: "%OUT_FILE%"

--- a/JamfCLI-Recipes/JamfPro-FilterComputers.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-FilterComputers.jamfclirunner.recipe.yaml
@@ -1,0 +1,23 @@
+Description: >
+  Lists computers from a Jamf Pro instance that match a filter expression,
+  e.g. by OS version or management status. Set FILTER to a jamf-cli filter
+  query such as "osVersion>=15" or "managed=true".
+  Uses the computers-inventories endpoint which supports --filter.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProFilterComputers
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  FILTER: managed=true
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: computers-inventories
+      action: list
+      profile: "%PROFILE%"
+      filter: "%FILTER%"
+      output: "%OUTPUT_FORMAT%"
+      out_file: "%RECIPE_CACHE_DIR%/filtered_computers.%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfPro-GetComputer.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-GetComputer.jamfclirunner.recipe.yaml
@@ -1,0 +1,22 @@
+Description: >
+  Retrieves the inventory record for a single computer from a Jamf Pro instance.
+  Set COMPUTER_ID to the numeric ID of the computer to look up.
+  Uses the computers-inventories endpoint; pro computers has no 'get' action.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProGetComputer
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  COMPUTER_ID: ""
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: computers-inventories
+      action: get
+      identifier: "%COMPUTER_ID%"
+      profile: "%PROFILE%"
+      out_file: "%RECIPE_CACHE_DIR%/computer_%COMPUTER_ID%.%OUTPUT_FORMAT%"
+      output: "%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfPro-ListAllComputers.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-ListAllComputers.jamfclirunner.recipe.yaml
@@ -1,0 +1,18 @@
+Description: Lists all computers from a Jamf Pro instance using jamf-cli.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProListAllComputers
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: computers
+      action: list
+      profile: "%PROFILE%"
+      all: true
+      output: "%OUTPUT_FORMAT%"
+      out_file: "%RECIPE_CACHE_DIR%/all_computers.%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfPro-ListComputerGroups.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-ListComputerGroups.jamfclirunner.recipe.yaml
@@ -1,0 +1,17 @@
+Description: Lists all computer groups from a Jamf Pro instance using jamf-cli.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProListComputerGroups
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: computer-groups
+      action: list
+      profile: "%PROFILE%"
+      output: "%OUTPUT_FORMAT%"
+      out_file: "%RECIPE_CACHE_DIR%/computer_groups.%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfPro-ListPolicies.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-ListPolicies.jamfclirunner.recipe.yaml
@@ -1,0 +1,17 @@
+Description: Lists all policies from a Jamf Pro instance using jamf-cli.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProListPolicies
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: classic-policies
+      action: list
+      profile: "%PROFILE%"
+      output: "%OUTPUT_FORMAT%"
+      out_file: "%RECIPE_CACHE_DIR%/policies.%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfPro-Overview.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-Overview.jamfclirunner.recipe.yaml
@@ -1,0 +1,18 @@
+Description: >
+  Displays a health and inventory snapshot of a Jamf Pro instance, including
+  enrollment counts, alerts, and security posture. Makes ~37 parallel API
+  calls to build the overview dashboard.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProOverview
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: overview
+      profile: "%PROFILE%"
+      output: "%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfPro-SecurityReport.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfPro-SecurityReport.jamfclirunner.recipe.yaml
@@ -1,0 +1,20 @@
+Description: >
+  Displays a fleet-wide security posture report for a Jamf Pro instance,
+  including FileVault, Gatekeeper, SIP, and activation lock status across
+  all managed devices.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProSecurityReport
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-pro-instance
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: report
+      action: security
+      profile: "%PROFILE%"
+      output: "%OUTPUT_FORMAT%"
+      out_file: "%RECIPE_CACHE_DIR%/security_report.%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfProtect-ExportPlan.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfProtect-ExportPlan.jamfclirunner.recipe.yaml
@@ -1,0 +1,21 @@
+Description: >
+  Exports a single Jamf Protect plan to a YAML file for backup or version
+  control. Set PLAN_ID to the ID or name of the plan to export.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProtectExportPlan
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-protect-instance
+  PLAN_ID: ""
+  OUT_FILE: "%RECIPE_CACHE_DIR%/plan-export.yaml"
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: protect
+      endpoint: plans
+      action: get
+      identifier: "%PLAN_ID%"
+      profile: "%PROFILE%"
+      output: yaml
+      out_file: "%OUT_FILE%"

--- a/JamfCLI-Recipes/JamfProtect-ListPlans.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfProtect-ListPlans.jamfclirunner.recipe.yaml
@@ -1,0 +1,18 @@
+Description: Lists all plans from a Jamf Protect tenant using jamf-cli.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProtectListPlans
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-protect-instance
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: protect
+      endpoint: plans
+      action: list
+      profile: "%PROFILE%"
+      all: true
+      out_file: "%RECIPE_CACHE_DIR%/plans.%OUTPUT_FORMAT%"
+      output: "%OUTPUT_FORMAT%"

--- a/JamfCLI-Recipes/JamfProtect-Overview.jamfclirunner.recipe.yaml
+++ b/JamfCLI-Recipes/JamfProtect-Overview.jamfclirunner.recipe.yaml
@@ -1,0 +1,18 @@
+Description: >
+  Displays the health and configuration dashboard for a Jamf Protect tenant.
+  Makes ~14 parallel API calls to build the overview.
+Identifier: com.github.grahampugh.recipes.jamfclirunner.JamfProtectOverview
+MinimumVersion: "2.3"
+
+Input:
+  PROFILE: my-jamf-protect-instance
+  OUTPUT_FORMAT: json
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: protect
+      endpoint: overview
+      profile: "%PROFILE%"
+      output: "%OUTPUT_FORMAT%"
+      out_file: "%RECIPE_CACHE_DIR%/overview.%OUTPUT_FORMAT%"

--- a/JamfCLI-Runner/JamfCLIRunner.py
+++ b/JamfCLI-Runner/JamfCLIRunner.py
@@ -1,0 +1,774 @@
+#!/usr/local/autopkg/python
+# pylint: disable=invalid-name
+
+"""
+Copyright 2026 Graham Pugh
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+NOTES:
+This processor provides an interface to the jamf-cli binary.
+
+Command structure:
+    jamf-cli <type> <endpoint> [<action>] [<identifier>] [flags]
+
+  type       - Top-level product namespace: pro, protect, multi.
+               The 'config' and 'completion' types are blocked.
+  endpoint   - API endpoint (e.g. 'computers', 'computer-groups', 'policies')
+               or a Power Command (e.g. 'group-tools', 'device').
+  action     - Action to perform on the endpoint (e.g. 'get', 'list',
+               'create', 'update', 'delete'). Not required for Power Commands
+               that act directly on an identifier.
+  identifier - Optional resource identifier (ID or name). Appended after the
+               action for standard CRUD endpoints, e.g.:
+                 jamf-cli pro computers get 123
+               For the 'device' Power Command, where the identifier comes
+               before the action (e.g. jamf-cli pro device 123 erase), set
+               identifier_before_action to True.
+
+Flags are derived from the optional input variables listed below. Flags whose
+values are empty, False, or not set are omitted from the command. Input keys
+use underscores in place of hyphens, e.g. 'out_file' maps to '--out-file'.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+# Matches ANSI/VT100 escape sequences (colours, cursor movement, etc.)
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b[@-_]")
+
+from autopkglib import Processor, ProcessorError  # pylint: disable=import-error
+
+__all__ = ["JamfCLIRunner"]
+
+# Types that must never be passed to jamf-cli from this processor
+BLOCKED_TYPES = {"config", "completion"}
+
+# Boolean flags: input key -> CLI flag
+BOOL_FLAGS = {
+    "all": "--all",
+    "scaffold": "--scaffold",
+    "dry_run": "--dry-run",
+    "confirm": "--yes",
+    "confirm_destructive": "--confirm-destructive",
+    "quiet": "--quiet",
+    "wide": "--wide",
+    "verbose": "--verbose",
+}
+
+# Value flags: input key -> CLI flag
+VALUE_FLAGS = {
+    "profile": "--profile",
+    "serial": "--serial",
+    "device_id": "--id",
+    "device_name": "--name",
+    "group": "--group",
+    "device_ids": "--ids",
+    "section": "--section",
+    "filter": "--filter",
+    "limit": "--limit",
+    "page": "--page",
+    "page_size": "--page-size",
+    "sort": "--sort",
+    "output": "-o",
+    "field": "--field",
+    "out_file": "--out-file",
+    "from_file": "--from-file",
+    "body_file": "--body-file",
+    "save_to": "--save-to",
+    "file": "--file",
+    "tenant_id": "--tenant-id",
+    "token_file": "--token-file",
+    "jamf_url": "--url",
+}
+
+
+class JamfCLIRunner(Processor):
+    """A processor for AutoPkg that interfaces with the jamf-cli binary.
+
+    Runs a jamf-cli command built from the provided input variables. The
+    'config' and 'completion' top-level types are blocked. Optional flags are
+    included only when their values are set; unset or falsy flags are silently
+    omitted, so the same recipe key set can be reused across endpoints and
+    actions without causing unknown-flag errors.
+    """
+
+    description = __doc__
+
+    input_variables = {
+        "pkg_path": {
+            "required": False,
+            "description": (
+                "Full path to a package file, typically set by an earlier AutoPkg "
+                "processor. If present and 'pkg_name' is not already set, the "
+                "processor derives 'pkg_name' as the basename of this path before "
+                "template substitution runs, making %pkg_name% available in templates."
+            ),
+        },
+        "pkg_name": {
+            "required": False,
+            "description": (
+                "Basename of the package file (e.g. 'MyApp-1.0.pkg'). Set explicitly "
+                "or derived automatically from 'pkg_path' if that key is present."
+            ),
+        },
+        "jamf_cli_binary": {
+            "required": False,
+            "description": (
+                "Path to the jamf-cli binary. Defaults to /usr/local/bin/jamf-cli."
+            ),
+            "default": "/usr/local/bin/jamf-cli",
+        },
+        "type": {
+            "required": True,
+            "description": (
+                "Top-level jamf-cli product namespace, e.g. 'pro', 'protect', 'multi'. "
+                "The 'config' and 'completion' types are not permitted."
+            ),
+        },
+        "endpoint": {
+            "required": True,
+            "description": (
+                "API endpoint or Power Command, e.g. 'computers', 'computer-groups', "
+                "'policies', 'device', 'group-tools'."
+            ),
+        },
+        "action": {
+            "required": False,
+            "description": (
+                "Action to perform, e.g. 'get', 'list', 'create', 'update', 'delete'. "
+                "Not required for Power Commands that act directly on an identifier."
+            ),
+        },
+        "identifier": {
+            "required": False,
+            "description": (
+                "Resource identifier (ID or name) passed as a positional argument. "
+                "By default it is placed after the action "
+                "(e.g. 'jamf-cli pro computers get 123'). "
+                "Set identifier_before_action to True for endpoints such as 'device' "
+                "where the identifier precedes the action "
+                "(e.g. 'jamf-cli pro device 123 erase')."
+            ),
+        },
+        "identifier_before_action": {
+            "required": False,
+            "description": (
+                "If True, the identifier is placed before the action rather than after. "
+                "Required for the 'device' Power Command and similar endpoints. "
+                "Defaults to False."
+            ),
+        },
+        "profile": {
+            "required": False,
+            "description": (
+                "The jamf-cli profile name identifying which Jamf Pro or Jamf Protect "
+                "instance to target, as configured via 'jamf-cli config'. "
+                "Maps to --profile <name>."
+            ),
+        },
+        # --- Boolean flags ---
+        "all": {
+            "required": False,
+            "description": "If True, passes --all to fetch all paginated results.",
+        },
+        "scaffold": {
+            "required": False,
+            "description": "If True, passes --scaffold to print a JSON template.",
+        },
+        "dry_run": {
+            "required": False,
+            "description": "If True, passes --dry-run to preview changes without applying them.",
+        },
+        "confirm": {
+            "required": False,
+            "description": "If True, passes --yes to jamf-cli to skip confirmation prompts.",
+        },
+        "confirm_destructive": {
+            "required": False,
+            "description": (
+                "If True, passes --confirm-destructive, required for bulk delete operations."
+            ),
+        },
+        "quiet": {
+            "required": False,
+            "description": "If True, passes --quiet to suppress non-error output.",
+        },
+        "wide": {
+            "required": False,
+            "description": "If True, passes --wide to show all columns in table output.",
+        },
+        "verbose": {
+            "required": False,
+            "description": "If True, passes --verbose to show HTTP debug info on stderr.",
+        },
+        # --- Device targeting flags ---
+        "serial": {
+            "required": False,
+            "description": "Device serial number. Maps to --serial <serial>.",
+        },
+        "device_id": {
+            "required": False,
+            "description": "Device numeric ID. Maps to --id <id>.",
+        },
+        "device_name": {
+            "required": False,
+            "description": "Device or resource name. Maps to --name <name>.",
+        },
+        "group": {
+            "required": False,
+            "description": "Target all members of a named device group. Maps to --group <name>.",
+        },
+        "device_ids": {
+            "required": False,
+            "description": "Comma-separated list of IDs for bulk operations. Maps to --ids <ids>.",
+        },
+        # --- Value flags ---
+        "section": {
+            "required": False,
+            "description": (
+                "Inventory section to return, e.g. 'GENERAL', 'HARDWARE'. "
+                "Maps to --section <section>."
+            ),
+        },
+        "save_to": {
+            "required": False,
+            "description": "File path to save downloaded content to. Maps to --save-to <path>.",
+        },
+        "file": {
+            "required": False,
+            "description": "Path to a file to upload. Maps to --file <path>.",
+        },
+        "filter": {
+            "required": False,
+            "description": (
+                "Filter query string, e.g. 'osVersion>=15'. Maps to --filter <value>."
+            ),
+        },
+        "limit": {
+            "required": False,
+            "description": "Maximum total results to return (0 = unlimited). Maps to --limit <n>.",
+        },
+        "page": {
+            "required": False,
+            "description": "Page number to fetch. Maps to --page <n>.",
+        },
+        "page_size": {
+            "required": False,
+            "description": "Number of items per page (default 100). Maps to --page-size <n>.",
+        },
+        "sort": {
+            "required": False,
+            "description": (
+                "Sorting criteria in the format 'property:asc/desc'. "
+                "Multiple criteria separated by comma, e.g. 'date:desc,name:asc'. "
+                "Maps to --sort <value>."
+            ),
+        },
+        "output": {
+            "required": False,
+            "description": (
+                "Output format: table, json, csv, yaml, or plain. Maps to -o <format>."
+            ),
+        },
+        "field": {
+            "required": False,
+            "description": "Extract a single named field from the response. Maps to --field <name>.",
+        },
+        "out_file": {
+            "required": False,
+            "description": "Write output to this file path. Maps to --out-file <path>.",
+        },
+        "from_file": {
+            "required": False,
+            "description": (
+                "Read input payload from this JSON or YAML file path. Maps to --from-file <path>. "
+                "If 'data' is also provided, 'from_file' takes precedence."
+            ),
+        },
+        "data": {
+            "required": False,
+            "description": (
+                "A dictionary of key-value pairs to pass as the --from-file payload. "
+                "Use this instead of 'from_file' when the content can be expressed inline "
+                'in the recipe, e.g. \'{"name": "%CATEGORY%", "priority": 10}\'. '
+                "The dictionary is serialised to a temporary JSON file which is automatically "
+                "cleaned up after the command runs. Ignored if 'from_file' is also set."
+            ),
+        },
+        "tenant_id": {
+            "required": False,
+            "description": (
+                "Jamf Pro tenant ID for platform gateway authentication. "
+                "Maps to --tenant-id <id> (or set JAMF_TENANT_ID env var)."
+            ),
+        },
+        "token_file": {
+            "required": False,
+            "description": "Path to a file containing an API token. Maps to --token-file <path>.",
+        },
+        "jamf_url": {
+            "required": False,
+            "description": (
+                "Jamf Pro/Protect server URL. Maps to --url <url> "
+                "(or set JAMF_URL env var)."
+            ),
+        },
+        "output_vars": {
+            "required": False,
+            "description": (
+                "Optional dictionary mapping new environment key names to source key names "
+                "from the JSON response. Use this to rename exported response keys so that "
+                "multiple processors can run without their output keys overwriting each other. "
+                "Keys in this dict are the desired environment variable names; values are the "
+                "source key names as exported from the JSON response. "
+                'Example: {"pkg_category_id": "id", "pkg_category_name": "name"}.'
+            ),
+        },
+    }
+
+    output_variables = {
+        "jamf_cli_output": {
+            "description": "The stdout output from the jamf-cli command.",
+        },
+        "jamf_cli_exit_code": {
+            "description": "The integer exit code returned by jamf-cli.",
+        },
+        "jamfclirunner_summary_result": {
+            "description": "Summary of the jamf-cli command that was executed.",
+        },
+        "jamf_cli_response": {
+            "description": (
+                "When the output is a JSON object (e.g. from get, create, apply, update), "
+                "the parsed dict is stored here. Each top-level key is also exported "
+                "individually to the environment so subsequent processors can reference "
+                "them directly, e.g. '%id%' or '%name%'."
+            ),
+        },
+    }
+
+    # Keys whose values are file paths and should be resolved via get_path_to_file
+    FILE_KEYS = {"from_file", "body_file", "file"}
+
+    def _coerce_data_value(self, value):
+        """Coerce a value from the 'data' dict to an appropriate JSON type.
+
+        AutoPkg variable substitution always produces strings, so "%PRIORITY%"
+        arrives as "10" and "%YES%" arrives as "true". This converts those
+        strings to int/float/bool where unambiguous, leaving everything else
+        as a plain string.
+        """
+        if not isinstance(value, str):
+            return value  # already int, bool, float, list, dict, etc.
+        stripped = value.strip()
+        if stripped.lower() == "true":
+            return True
+        if stripped.lower() == "false":
+            return False
+        try:
+            return int(stripped)
+        except ValueError:
+            pass
+        try:
+            return float(stripped)
+        except ValueError:
+            pass
+        return value
+
+    def _coerce_data_dict(self, d):
+        """Recursively coerce all values in a dict via _coerce_data_value."""
+        return {
+            k: (
+                self._coerce_data_dict(v)
+                if isinstance(v, dict)
+                else self._coerce_data_value(v)
+            )
+            for k, v in d.items()
+        }
+
+    def substitute_assignable_keys(self, text):
+        """Replace all %KEY% tokens in text with values from the AutoPkg environment.
+
+        Uses up to five passes so that substitutions whose values themselves
+        contain %KEY% tokens are fully resolved. Raises ProcessorError if any
+        token remains unresolvable after all passes.
+        """
+        for _ in range(5):
+            found_keys = re.findall(r"%(\w+)%", text)
+            if not found_keys:
+                break
+            for key in found_keys:
+                value = self.env.get(key)
+                if value is not None:
+                    self.output(
+                        f"Substituting %{key}% with {str(value)!r}",
+                        verbose_level=2,
+                    )
+                    text = text.replace(f"%{key}%", str(value))
+                else:
+                    raise ProcessorError(
+                        f"Unsubstitutable key in template: '%{key}%'"
+                    )
+        return text
+
+    def _substitute_file(self, file_path, tmp_files):
+        """Read a template file, substitute %KEY% tokens, and write the result
+        to a new temporary file. Returns the path to the substituted file and
+        appends it to tmp_files for later cleanup."""
+        try:
+            with open(file_path, "r", encoding="utf-8") as fh:
+                original = fh.read()
+        except OSError as e:
+            raise ProcessorError(f"Could not read template file {file_path}: {e}") from e
+
+        substituted = self.substitute_assignable_keys(original)
+
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=os.path.splitext(file_path)[1] or ".json",
+            delete=False, encoding="utf-8",
+        )
+        tmp.write(substituted)
+        tmp.close()
+        tmp_files.append(tmp.name)
+        self.output(f"Wrote substituted template to: {tmp.name}")
+        return tmp.name
+
+    def get_path_to_file(self, filename):
+        """Find a file without requiring a full path. Searches in order:
+        1. RecipeOverrides directories (recursive)
+        2. Same directory as the recipe
+        3. Sibling directories of the recipe directory
+        4. Recipe search directories (repo roots) that match the recipe's location
+        5. Parent recipe's repo if running as an override
+        """
+        recipe_dir = self.env.get("RECIPE_DIR")
+        recipe_dir_path = Path(os.path.expanduser(recipe_dir))
+        matched_override_dir = ""
+        matched_filepath = ""
+
+        # 1. RecipeOverrides directories
+        self.output(f"Looking for {filename} in RECIPE_OVERRIDE_DIRS", verbose_level=3)
+        if self.env.get("RECIPE_OVERRIDE_DIRS"):
+            for d in self.env["RECIPE_OVERRIDE_DIRS"]:
+                override_dir_path = Path(os.path.expanduser(d))
+                if (
+                    override_dir_path == recipe_dir_path
+                    or override_dir_path in recipe_dir_path.parents
+                ):
+                    self.output(f"Matching dir: {override_dir_path}", verbose_level=3)
+                    matched_override_dir = override_dir_path
+                for path in Path(os.path.expanduser(d)).rglob(filename):
+                    matched_filepath = str(path)
+                    break
+            if matched_filepath:
+                self.output(f"File found at: {matched_filepath}")
+                return matched_filepath
+        else:
+            self.output("No RECIPE_OVERRIDE_DIRS defined", verbose_level=3)
+
+        # 2. Same directory as the recipe
+        self.output(
+            f"Looking for {filename} in {recipe_dir} or its siblings", verbose_level=3
+        )
+        filepath = os.path.join(recipe_dir, filename)
+        if os.path.exists(filepath):
+            self.output(f"File found at: {filepath}")
+            return filepath
+
+        # 3. Sibling directories
+        self.output(
+            f"Checking sibling directories of {recipe_dir_path}", verbose_level=3
+        )
+        for sibling in recipe_dir_path.parent.iterdir():
+            if sibling.is_dir() and sibling != recipe_dir_path:
+                self.output(
+                    f"Looking for {filename} in sibling directory: {sibling}",
+                    verbose_level=3,
+                )
+                filepath = os.path.join(sibling, filename)
+                if os.path.exists(filepath):
+                    self.output(f"File found at: {filepath}")
+                    return filepath
+
+        # 4. Recipe search directories (repo roots)
+        if self.env.get("RECIPE_SEARCH_DIRS"):
+            matched_filepath = ""
+            for d in self.env["RECIPE_SEARCH_DIRS"]:
+                search_dir_path = Path(os.path.expanduser(d))
+                self.output(f"Recipe directory: {recipe_dir_path}", verbose_level=3)
+                self.output(
+                    f"Looking for {filename} in {search_dir_path}", verbose_level=3
+                )
+                if (
+                    search_dir_path == recipe_dir_path
+                    or search_dir_path.parent == recipe_dir_path.parent
+                    or search_dir_path == recipe_dir_path.parent
+                    or search_dir_path in recipe_dir_path.parent.parents
+                ):
+                    self.output(f"Matching dir: {search_dir_path}", verbose_level=3)
+                    for path in Path(os.path.expanduser(d)).rglob(filename):
+                        matched_filepath = str(path)
+                        break
+                if matched_filepath:
+                    self.output(f"File found at: {matched_filepath}")
+                    return matched_filepath
+            self.output(
+                f"File {filename} not found in any RECIPE_SEARCH_DIRS", verbose_level=3
+            )
+
+        # 5. Parent recipe's repo if running as an override
+        if matched_override_dir:
+            if self.env.get("PARENT_RECIPES"):
+                self.output(
+                    f"Looking for {filename} in parent recipe's repo", verbose_level=3
+                )
+                matched_filepath = ""
+                parent = self.env["PARENT_RECIPES"][0]
+                self.output(f"Parent Recipe: {parent}", verbose_level=2)
+                parent_dir = os.path.dirname(parent)
+                parent_dir_path = Path(os.path.expanduser(parent_dir))
+                for d in self.env.get("RECIPE_SEARCH_DIRS", []):
+                    search_dir_path = Path(os.path.expanduser(d))
+                    if (
+                        search_dir_path == parent_dir_path
+                        or search_dir_path in parent_dir_path.parents
+                    ):
+                        self.output(f"Matching dir: {search_dir_path}", verbose_level=3)
+                        for path in Path(os.path.expanduser(d)).rglob(filename):
+                            matched_filepath = str(path)
+                            break
+                    if matched_filepath:
+                        self.output(f"File found at: {matched_filepath}")
+                        return matched_filepath
+
+        raise ProcessorError(f"File '{filename}' not found")
+
+    def _is_truthy(self, value):
+        """Return True if value represents a truthy boolean input."""
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() not in ("", "false", "0", "no", "none")
+
+    def _build_command(self, binary, cli_type, endpoint, action, identifier, id_before):
+        """Assemble the positional part of the jamf-cli command."""
+        # --no-color and --no-input are always set: plist serialisation requires
+        # clean text, and AutoPkg recipes must never block on interactive prompts.
+        cmd = [binary, "--no-color", "--no-input", cli_type, endpoint]
+
+        if identifier and id_before:
+            cmd.append(identifier)
+
+        if action:
+            cmd.append(action)
+
+        if identifier and not id_before:
+            cmd.append(identifier)
+
+        return cmd
+
+    def _append_flags(self, cmd):
+        """Append optional flags to cmd based on set input variables."""
+        for key, flag in BOOL_FLAGS.items():
+            if self._is_truthy(self.env.get(key)):
+                cmd.append(flag)
+
+        for key, flag in VALUE_FLAGS.items():
+            value = self.env.get(key)
+            if value is not None and str(value).strip():
+                cmd.extend([flag, str(value).strip()])
+
+        return cmd
+
+    def main(self):
+        """Build and execute the jamf-cli command."""
+        binary = self.env.get("jamf_cli_binary") or "/usr/local/bin/jamf-cli"
+        cli_type = self.env.get("type", "").strip()
+        endpoint = self.env.get("endpoint", "").strip()
+        action = (self.env.get("action") or "").strip() or None
+        identifier = (self.env.get("identifier") or "").strip() or None
+        id_before = self._is_truthy(self.env.get("identifier_before_action"))
+
+        # Validate binary
+        if not shutil.which(binary):
+            raise ProcessorError(f"jamf-cli binary not found: {binary}")
+
+        # Validate type
+        if not cli_type:
+            raise ProcessorError("The 'type' input variable is required.")
+        if cli_type.lower() in BLOCKED_TYPES:
+            raise ProcessorError(
+                f"The '{cli_type}' type is not permitted. "
+                f"Blocked types: {', '.join(sorted(BLOCKED_TYPES))}."
+            )
+
+        # Validate endpoint
+        if not endpoint:
+            raise ProcessorError("The 'endpoint' input variable is required.")
+
+        # Track all temporary files created during this run for cleanup.
+        tmp_files = []
+        # Also record which env keys we set from temp files so they can be
+        # cleared after the run, preventing stale paths leaking to the next
+        # processor invocation in the same recipe.
+        tmp_env_keys = []
+
+        # If 'data' is provided and 'from_file' is not, serialise 'data' to a
+        # temporary JSON file and use that as the --from-file value.
+        data_value = self.env.get("data")
+        from_file_value = (self.env.get("from_file") or "").strip()
+        if data_value is not None and not from_file_value:
+            if not isinstance(data_value, dict):
+                raise ProcessorError(
+                    f"'data' must be a dictionary, got {type(data_value).__name__}"
+                )
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False
+            )
+            json.dump(self._coerce_data_dict(data_value), tmp, indent=2)
+            tmp.close()
+            tmp_files.append(tmp.name)
+            tmp_env_keys.append("from_file")
+            self.env["from_file"] = tmp.name
+            self.output(f"Wrote 'data' to temporary file: {tmp.name}")
+
+        # Resolve file-type inputs to absolute paths
+        for key in self.FILE_KEYS:
+            value = (self.env.get(key) or "").strip()
+            if value and not os.path.isabs(value):
+                self.env[key] = self.get_path_to_file(value)
+
+        # If pkg_path is in the environment and pkg_name is not already set,
+        # derive pkg_name from the basename so templates can reference %pkg_name%.
+        if self.env.get("pkg_path") and not self.env.get("pkg_name"):
+            self.env["pkg_name"] = os.path.basename(self.env["pkg_path"])
+            self.output(
+                f"Derived pkg_name: {self.env['pkg_name']!r} from pkg_path",
+                verbose_level=2,
+            )
+
+        # Substitute %KEY% tokens in from_file and body_file template content.
+        # 'file' is left as-is because it may be a binary (package, script, etc.)
+        # that should not be text-processed.
+        for key in ("from_file", "body_file"):
+            value = (self.env.get(key) or "").strip()
+            if value and os.path.isfile(value):
+                substituted_path = self._substitute_file(value, tmp_files)
+                if key not in tmp_env_keys:
+                    tmp_env_keys.append(key)
+                self.env[key] = substituted_path
+
+        # Build command
+        cmd = self._build_command(
+            binary, cli_type, endpoint, action, identifier, id_before
+        )
+        cmd = self._append_flags(cmd)
+
+        self.output(f"Running: {' '.join(cmd)}")
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = proc.communicate()
+            exit_code = proc.returncode
+        finally:
+            for path in tmp_files:
+                if os.path.exists(path):
+                    os.unlink(path)
+            # Clear env keys that pointed at temp files so that a subsequent
+            # processor in the same recipe does not inherit stale paths.
+            for key in tmp_env_keys:
+                self.env[key] = ""
+
+        stdout_str = _ANSI_ESCAPE.sub(
+            "", stdout.decode("utf-8", errors="replace")
+        ).strip()
+        stderr_str = _ANSI_ESCAPE.sub(
+            "", stderr.decode("utf-8", errors="replace")
+        ).strip()
+
+        if stdout_str:
+            self.output(f"Output:\n{stdout_str}")
+        if stderr_str:
+            self.output(f"Stderr:\n{stderr_str}", verbose_level=2)
+
+        self.env["jamf_cli_output"] = stdout_str
+        self.env["jamf_cli_exit_code"] = exit_code
+
+        if exit_code != 0:
+            raise ProcessorError(
+                f"jamf-cli exited with code {exit_code}."
+                + (f" Stderr: {stderr_str}" if stderr_str else "")
+            )
+
+        # Parse JSON output and export top-level keys so subsequent processors
+        # can reference them directly, e.g. %id% or %name%.
+        # Only applies when the response is a JSON object; arrays (list output)
+        # are skipped since they have no meaningful top-level key mapping.
+        if stdout_str:
+            try:
+                parsed = json.loads(stdout_str)
+                if isinstance(parsed, dict):
+                    self.env["jamf_cli_response"] = parsed
+                    for key, value in parsed.items():
+                        self.env[key] = value
+                        self.output(
+                            f"Exported response key: {key} = {value!r}",
+                            verbose_level=2,
+                        )
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        # Apply output_vars remapping: for each new_key -> source_key entry,
+        # copy the value of source_key in the env to new_key.
+        output_vars = self.env.get("output_vars")
+        if output_vars:
+            if not isinstance(output_vars, dict):
+                raise ProcessorError(
+                    f"'output_vars' must be a dictionary, got {type(output_vars).__name__}"
+                )
+            for new_key, source_key in output_vars.items():
+                if source_key in self.env:
+                    self.env[new_key] = self.env[source_key]
+                    self.output(
+                        f"Mapped response key: {source_key!r} -> {new_key!r} = {self.env[new_key]!r}",
+                        verbose_level=2,
+                    )
+                else:
+                    self.output(
+                        f"output_vars: source key {source_key!r} not found in environment, skipping",
+                        verbose_level=2,
+                    )
+
+        self.env["jamfclirunner_summary_result"] = {
+            "summary_text": "The following jamf-cli command was run:",
+            "report_fields": ["command", "exit_code"],
+            "data": {
+                "command": " ".join(cmd),
+                "exit_code": str(exit_code),
+            },
+        }
+
+
+if __name__ == "__main__":
+    PROCESSOR = JamfCLIRunner()
+    PROCESSOR.execute_shell()

--- a/JamfCLI-Runner/JamfCLIRunner.py
+++ b/JamfCLI-Runner/JamfCLIRunner.py
@@ -645,22 +645,29 @@ class JamfCLIRunner(Processor):
         # processor invocation in the same recipe.
         tmp_env_keys = []
 
-        # If 'data' is provided and 'from_file' is not, serialise 'data' to a
-        # temporary JSON file and use that as the --from-file value.
-        data_value = self.env.get("data")
-        from_file_value = (self.env.get("from_file") or "").strip()
-        if data_value is not None and not from_file_value:
-            if not isinstance(data_value, dict):
-                raise ProcessorError(
-                    f"'data' must be a dictionary, got {type(data_value).__name__}"
-                )
-            tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-            json.dump(self._coerce_data_dict(data_value), tmp, indent=2)
-            tmp.close()
-            tmp_files.append(tmp.name)
-            tmp_env_keys.append("from_file")
-            self.env["from_file"] = tmp.name
-            self.output(f"Wrote 'data' to temporary file: {tmp.name}")
+        # Commands that accept --file (binary/multipart uploads) never also
+        # accept --from-file (JSON/YAML body). Skip all body-file processing
+        # when --file is in use so those commands are not given a spurious
+        # --from-file argument.
+        using_file_upload = bool((self.env.get("file") or "").strip())
+
+        if not using_file_upload:
+            # If 'data' is provided and 'from_file' is not, serialise 'data' to a
+            # temporary JSON file and use that as the --from-file value.
+            data_value = self.env.get("data")
+            from_file_value = (self.env.get("from_file") or "").strip()
+            if data_value is not None and not from_file_value:
+                if not isinstance(data_value, dict):
+                    raise ProcessorError(
+                        f"'data' must be a dictionary, got {type(data_value).__name__}"
+                    )
+                tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+                json.dump(self._coerce_data_dict(data_value), tmp, indent=2)
+                tmp.close()
+                tmp_files.append(tmp.name)
+                tmp_env_keys.append("from_file")
+                self.env["from_file"] = tmp.name
+                self.output(f"Wrote 'data' to temporary file: {tmp.name}")
 
         # Resolve file-type inputs to absolute paths
         for key in self.FILE_KEYS:
@@ -677,16 +684,17 @@ class JamfCLIRunner(Processor):
                 verbose_level=2,
             )
 
-        # Substitute %KEY% tokens in from_file and body_file template content.
-        # 'file' is left as-is because it may be a binary (package, script, etc.)
-        # that should not be text-processed.
-        for key in ("from_file", "body_file"):
-            value = (self.env.get(key) or "").strip()
-            if value and os.path.isfile(value):
-                substituted_path = self._substitute_file(value, tmp_files)
-                if key not in tmp_env_keys:
-                    tmp_env_keys.append(key)
-                self.env[key] = substituted_path
+        if not using_file_upload:
+            # Substitute %KEY% tokens in from_file and body_file template content.
+            # 'file' is left as-is because it is a binary (package, script, etc.)
+            # that should not be text-processed.
+            for key in ("from_file", "body_file"):
+                value = (self.env.get(key) or "").strip()
+                if value and os.path.isfile(value):
+                    substituted_path = self._substitute_file(value, tmp_files)
+                    if key not in tmp_env_keys:
+                        tmp_env_keys.append(key)
+                    self.env[key] = substituted_path
 
         # Build command
         cmd = self._build_command(

--- a/JamfCLI-Runner/JamfCLIRunner.py
+++ b/JamfCLI-Runner/JamfCLIRunner.py
@@ -52,6 +52,10 @@ from pathlib import Path
 # Matches ANSI/VT100 escape sequences (colours, cursor movement, etc.)
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b[@-_]")
 
+# Matches HTTP response status lines in jamf-cli --verbose stderr output,
+# e.g. "<-- 200 200 OK" or "<-- 409 409 Conflict"
+_HTTP_RESPONSE_RE = re.compile(r"<--\s+(\d{3})")
+
 from autopkglib import Processor, ProcessorError  # pylint: disable=import-error
 
 __all__ = ["JamfCLIRunner"]
@@ -130,9 +134,9 @@ class JamfCLIRunner(Processor):
         "jamf_cli_binary": {
             "required": False,
             "description": (
-                "Path to the jamf-cli binary. Defaults to /usr/local/bin/jamf-cli."
+                "Path to the jamf-cli binary. Defaults to 'jamf-cli' in the system PATH."
             ),
-            "default": "/usr/local/bin/jamf-cli",
+            "default": "jamf-cli",
         },
         "type": {
             "required": True,
@@ -360,6 +364,16 @@ class JamfCLIRunner(Processor):
                 "them directly, e.g. '%id%' or '%name%'."
             ),
         },
+        "object_updated": {
+            "description": (
+                "True if the object was created or updated (exit code 0). "
+                "False if jamf-cli exited with code 1 but all observed HTTP responses "
+                "were 2xx, which indicates the object already existed and was intentionally "
+                "not replaced (e.g. 'apply' without '--yes'). "
+                "Use with StopProcessingIf to halt subsequent processors when no change "
+                "was made: predicate 'object_updated == False'."
+            ),
+        },
     }
 
     # Keys whose values are file paths and should be resolved via get_path_to_file
@@ -421,9 +435,7 @@ class JamfCLIRunner(Processor):
                     )
                     text = text.replace(f"%{key}%", str(value))
                 else:
-                    raise ProcessorError(
-                        f"Unsubstitutable key in template: '%{key}%'"
-                    )
+                    raise ProcessorError(f"Unsubstitutable key in template: '%{key}%'")
         return text
 
     def _substitute_file(self, file_path, tmp_files):
@@ -434,13 +446,17 @@ class JamfCLIRunner(Processor):
             with open(file_path, "r", encoding="utf-8") as fh:
                 original = fh.read()
         except OSError as e:
-            raise ProcessorError(f"Could not read template file {file_path}: {e}") from e
+            raise ProcessorError(
+                f"Could not read template file {file_path}: {e}"
+            ) from e
 
         substituted = self.substitute_assignable_keys(original)
 
         tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=os.path.splitext(file_path)[1] or ".json",
-            delete=False, encoding="utf-8",
+            mode="w",
+            suffix=os.path.splitext(file_path)[1] or ".json",
+            delete=False,
+            encoding="utf-8",
         )
         tmp.write(substituted)
         tmp.close()
@@ -598,7 +614,7 @@ class JamfCLIRunner(Processor):
 
     def main(self):
         """Build and execute the jamf-cli command."""
-        binary = self.env.get("jamf_cli_binary") or "/usr/local/bin/jamf-cli"
+        binary = self.env.get("jamf_cli_binary") or "jamf-cli"
         cli_type = self.env.get("type", "").strip()
         endpoint = self.env.get("endpoint", "").strip()
         action = (self.env.get("action") or "").strip() or None
@@ -638,9 +654,7 @@ class JamfCLIRunner(Processor):
                 raise ProcessorError(
                     f"'data' must be a dictionary, got {type(data_value).__name__}"
                 )
-            tmp = tempfile.NamedTemporaryFile(
-                mode="w", suffix=".json", delete=False
-            )
+            tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
             json.dump(self._coerce_data_dict(data_value), tmp, indent=2)
             tmp.close()
             tmp_files.append(tmp.name)
@@ -714,17 +728,38 @@ class JamfCLIRunner(Processor):
         self.env["jamf_cli_output"] = stdout_str
         self.env["jamf_cli_exit_code"] = exit_code
 
+        # Determine whether the operation made a change and whether a non-zero
+        # exit code represents a real failure or a deliberate no-op.
+        #
+        # jamf-cli exits 1 when an object already exists and --yes was not
+        # supplied (e.g. `apply` without `--confirm`).  In that case all HTTP
+        # activity visible in --verbose stderr is successful (2xx), so we treat
+        # the run as a soft success: object_updated = False, no exception raised.
+        #
+        # Any other non-zero exit (4xx/5xx responses, no HTTP activity, etc.)
+        # is still surfaced as a ProcessorError.
+        object_updated = True
         if exit_code != 0:
-            raise ProcessorError(
-                f"jamf-cli exited with code {exit_code}."
-                + (f" Stderr: {stderr_str}" if stderr_str else "")
-            )
+            http_codes = [int(c) for c in _HTTP_RESPONSE_RE.findall(stderr_str)]
+            if http_codes and all(200 <= c < 300 for c in http_codes):
+                object_updated = False
+                self.output(
+                    f"jamf-cli exited with code {exit_code} but all HTTP responses "
+                    f"were successful {http_codes} — object already exists, no change made."
+                )
+            else:
+                raise ProcessorError(
+                    f"jamf-cli exited with code {exit_code}."
+                    + (f" Stderr: {stderr_str}" if stderr_str else "")
+                )
 
         # Parse JSON output and export top-level keys so subsequent processors
         # can reference them directly, e.g. %id% or %name%.
-        # Only applies when the response is a JSON object; arrays (list output)
-        # are skipped since they have no meaningful top-level key mapping.
-        if stdout_str:
+        # Only done when the object was actually created/updated; when
+        # object_updated is False the stdout contains a jamf-cli error envelope
+        # (with keys like "error", "message") that should not pollute the env.
+        # Arrays (list output) are also skipped as they have no useful key mapping.
+        if object_updated and stdout_str:
             try:
                 parsed = json.loads(stdout_str)
                 if isinstance(parsed, dict):
@@ -759,12 +794,15 @@ class JamfCLIRunner(Processor):
                         verbose_level=2,
                     )
 
+        self.env["object_updated"] = object_updated
+
         self.env["jamfclirunner_summary_result"] = {
             "summary_text": "The following jamf-cli command was run:",
-            "report_fields": ["command", "exit_code"],
+            "report_fields": ["command", "exit_code", "object_updated"],
             "data": {
                 "command": " ".join(cmd),
                 "exit_code": str(exit_code),
+                "object_updated": str(object_updated),
             },
         }
 

--- a/JamfCLI-Runner/JamfCLIRunner.py
+++ b/JamfCLI-Runner/JamfCLIRunner.py
@@ -308,11 +308,12 @@ class JamfCLIRunner(Processor):
         "data": {
             "required": False,
             "description": (
-                "A dictionary of key-value pairs to pass as the --from-file payload. "
+                "A dictionary of key-value pairs to pass as an inline JSON argument. "
                 "Use this instead of 'from_file' when the content can be expressed inline "
                 'in the recipe, e.g. \'{"name": "%CATEGORY%", "priority": 10}\'. '
-                "The dictionary is serialised to a temporary JSON file which is automatically "
-                "cleaned up after the command runs. Ignored if 'from_file' is also set."
+                "The dictionary is serialised to a JSON string and appended as a positional "
+                "argument to the command — no file is written to disk. "
+                "Ignored if 'from_file' is also set."
             ),
         },
         "tenant_id": {
@@ -651,9 +652,11 @@ class JamfCLIRunner(Processor):
         # --from-file argument.
         using_file_upload = bool((self.env.get("file") or "").strip())
 
+        # If 'data' is provided and 'from_file' is not, serialise it to a JSON
+        # string to be fed via stdin (equivalent to <<< '...' in shell). No file
+        # is written to disk.
+        data_json = None
         if not using_file_upload:
-            # If 'data' is provided and 'from_file' is not, serialise 'data' to a
-            # temporary JSON file and use that as the --from-file value.
             data_value = self.env.get("data")
             from_file_value = (self.env.get("from_file") or "").strip()
             if data_value is not None and not from_file_value:
@@ -661,13 +664,7 @@ class JamfCLIRunner(Processor):
                     raise ProcessorError(
                         f"'data' must be a dictionary, got {type(data_value).__name__}"
                     )
-                tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-                json.dump(self._coerce_data_dict(data_value), tmp, indent=2)
-                tmp.close()
-                tmp_files.append(tmp.name)
-                tmp_env_keys.append("from_file")
-                self.env["from_file"] = tmp.name
-                self.output(f"Wrote 'data' to temporary file: {tmp.name}")
+                data_json = json.dumps(self._coerce_data_dict(data_value))
 
         # Resolve file-type inputs to absolute paths
         for key in self.FILE_KEYS:
@@ -702,15 +699,20 @@ class JamfCLIRunner(Processor):
         )
         cmd = self._append_flags(cmd)
 
-        self.output(f"Running: {' '.join(cmd)}")
+        if data_json:
+            self.output(f"Running: {' '.join(cmd)} <<< '<data>'")
+        else:
+            self.output(f"Running: {' '.join(cmd)}")
 
         try:
             proc = subprocess.Popen(
                 cmd,
+                stdin=subprocess.PIPE if data_json else None,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            stdout, stderr = proc.communicate()
+            stdin_bytes = data_json.encode("utf-8") if data_json else None
+            stdout, stderr = proc.communicate(input=stdin_bytes)
             exit_code = proc.returncode
         finally:
             for path in tmp_files:

--- a/JamfCLI-Runner/JamfCLIRunner.recipe
+++ b/JamfCLI-Runner/JamfCLIRunner.recipe
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Recipe stub for any Processors in this directory.</string>
+	<key>Identifier</key>
+	<string>com.github.grahampugh.recipes.JamfCLIRunner</string>
+	<key>Input</key>
+	<dict/>
+	<key>MinimumVersion</key>
+	<string>0.4.0</string>
+	<key>Process</key>
+	<array/>
+</dict>
+</plist>

--- a/JamfCLI-Runner/README.md
+++ b/JamfCLI-Runner/README.md
@@ -138,7 +138,11 @@ Where the temporary file contains:
 }
 ```
 
-The temporary file is created before the command runs and deleted immediately afterwards, even if the command fails.
+The dictionary is serialised to a JSON string and passed to jamf-cli via stdin — no file is written to disk. This is equivalent to the shell herestring form:
+
+```sh
+jamf-cli pro categories apply <<< '{"name":"Utilities","priority":9}'
+```
 
 ---
 

--- a/JamfCLI-Runner/README.md
+++ b/JamfCLI-Runner/README.md
@@ -1,0 +1,349 @@
+# JamfCLIRunner
+
+An AutoPkg processor that runs commands against the [jamf-cli](https://concepts.jamf.com/jamf-cli/) binary, enabling AutoPkg recipes to create, update, query, and manage objects in Jamf Pro and Jamf Protect.
+
+## Prerequisites
+
+- **jamf-cli** must be installed and available in the system `PATH` (or set `jamf_cli_binary` to its absolute path).
+- At least one profile must be configured via `jamf-cli config` identifying a Jamf Pro or Jamf Protect instance.
+
+## Processor reference
+
+### Command structure
+
+The processor constructs and runs:
+
+```sh
+jamf-cli --no-color --no-input <type> <endpoint> [<action>] [<identifier>] [flags]
+```
+
+`--no-color` and `--no-input` are always set. All other flags are derived from input variables and are silently omitted when not set.
+
+### Referencing the processor in a recipe
+
+```yaml
+- Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+```
+
+### Required input variables
+
+| Key | Description |
+|-----|-------------|
+| `type` | Top-level product namespace: `pro`, `protect`, or `multi`. The `config` and `completion` types are blocked. |
+| `endpoint` | API endpoint or Power Command, e.g. `categories`, `computers`, `icons`, `plans`. |
+
+### Common optional input variables
+
+| Key | CLI flag | Description |
+|-----|----------|-------------|
+| `action` | positional | Action to perform: `get`, `list`, `apply`, `delete`, `upload`, etc. |
+| `identifier` | positional | Resource ID or name, placed after the action by default. |
+| `identifier_before_action` | — | If `true`, the identifier is placed before the action (required for the `device` Power Command). |
+| `profile` | `--profile` | jamf-cli profile name identifying the target instance. |
+| `confirm` | `--yes` | If truthy, passes `--yes` to skip confirmation prompts. |
+| `confirm_destructive` | `--confirm-destructive` | Required for bulk-delete operations. |
+| `dry_run` | `--dry-run` | Preview changes without applying them. |
+| `all` | `--all` | Fetch all paginated results (valid on `list` and `history` actions). |
+| `verbose` | `--verbose` | Show HTTP debug info on stderr. Recommended when using `object_updated`. |
+| `output` | `-o` | Output format: `table`, `json`, `csv`, `yaml`, or `plain`. |
+| `filter` | `--filter` | Filter query, e.g. `osVersion>=15`. Only supported on `computers-inventories`. |
+| `sort` | `--sort` | Sort criteria, e.g. `name:asc`. |
+| `out_file` | `--out-file` | Write output to a file path. |
+| `from_file` | `--from-file` | Path to a JSON or YAML payload file. Supports `%KEY%` substitution. |
+| `body_file` | `--body-file` | Alternative body file flag for endpoints that use `--body-file`. Supports `%KEY%` substitution. |
+| `data` | `--from-file` | Inline dictionary payload written to a temporary JSON file. Ignored if `from_file` is set. |
+| `file` | `--file` | Path to a binary file to upload (packages, scripts, icons). When set, `from_file`/`data` processing is skipped entirely. |
+| `serial` | `--serial` | Target device by serial number. |
+| `device_id` | `--id` | Target device by numeric ID. |
+| `device_name` | `--name` | Target device or resource by name. |
+| `output_vars` | — | Dictionary mapping new env key names to response key names (see [output_vars](#output_vars)). |
+
+### Output variables
+
+| Key | Description |
+|-----|-------------|
+| `jamf_cli_output` | Raw stdout from the command. |
+| `jamf_cli_exit_code` | Integer exit code. |
+| `jamf_cli_response` | Parsed JSON response dict (when the output is a JSON object). |
+| `object_updated` | `True` if the object was created or updated; `False` if it already existed and was intentionally not replaced. See [object_updated](#object_updated). |
+| `jamfclirunner_summary_result` | AutoPkg summary shown at the end of the run. |
+| *(response keys)* | Each top-level key from a JSON object response is also exported individually, e.g. `%id%`, `%name%`. |
+
+---
+
+## Examples
+
+### 1. List all computers
+
+```yaml
+- Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+  Arguments:
+    type: pro
+    endpoint: computers
+    action: list
+    profile: "%PROFILE%"
+    all: true
+```
+
+Equivalent command: `jamf-cli --no-color --no-input pro computers list --all --profile my-instance`
+
+---
+
+### 2. Get a computer by serial number
+
+```yaml
+- Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+  Arguments:
+    type: pro
+    endpoint: computers-inventories
+    action: get
+    profile: "%PROFILE%"
+    serial: "%SERIAL%"
+```
+
+The response keys (`id`, `name`, `udid`, etc.) are exported to the environment automatically and can be referenced as `%id%`, `%name%` in subsequent processors.
+
+---
+
+### 3. Inline payload with `data`
+
+Use `data` when the JSON body is simple enough to write directly in the recipe. Values from `%VARIABLE%` substitution are coerced to the appropriate JSON type (`"10"` → `10`, `"true"` → `true`).
+
+```yaml
+Input:
+  CATEGORY: Utilities
+  PRIORITY: "9"
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: categories
+      action: apply
+      profile: "%PROFILE%"
+      confirm: "true"
+      data:
+        name: "%CATEGORY%"
+        priority: "%PRIORITY%"
+```
+
+Equivalent command: `jamf-cli --no-color --no-input pro categories apply --yes --profile my-instance --from-file /tmp/tmpXXXX.json`
+
+Where the temporary file contains:
+
+```json
+{
+  "name": "Utilities",
+  "priority": 9
+}
+```
+
+The temporary file is created before the command runs and deleted immediately afterwards, even if the command fails.
+
+---
+
+### 4. Template file with `from_file` and variable substitution
+
+For more complex payloads, place a JSON or YAML template file alongside the recipe. Any `%KEY%` tokens in the file are substituted from the AutoPkg environment before the file is passed to jamf-cli.
+
+**`JamfPro-Package.json`** (in the same folder as the recipe):
+
+```json
+{
+  "packageName": "%pkg_name%",
+  "notes": "%pkg_notes%",
+  "priority": "%pkg_priority%"
+}
+```
+
+**Recipe:**
+
+```yaml
+Input:
+  pkg_notes: Uploaded by AutoPkg
+  pkg_priority: "10"
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: packages
+      action: apply
+      profile: "%PROFILE%"
+      confirm: "true"
+      from_file: JamfPro-Package.json
+```
+
+`pkg_name` is derived automatically from `pkg_path` if it is set by an earlier processor (e.g. a download or packaging step).
+
+The processor searches for the template file in this order:
+
+1. RecipeOverrides directories (recursive)
+2. The same directory as the recipe
+3. Sibling directories of the recipe directory
+4. Recipe search directories (repo roots)
+5. The parent recipe's repo (when running as an override)
+
+---
+
+### 5. File upload with `--file`
+
+Commands that perform binary uploads (packages, scripts, icons, config profiles) use `--file` rather than `--from-file`. Setting the `file` key automatically disables `data`/`from_file` processing so no spurious `--from-file` argument is added.
+
+```yaml
+- Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+  Arguments:
+    type: pro
+    endpoint: icons
+    action: upload
+    profile: "%PROFILE%"
+    file: "%app_icon_path%"
+    output_vars:
+      app_icon_id: id
+      app_icon_url: url
+```
+
+---
+
+### 6. Multi-processor workflow with `output_vars`
+
+When a recipe runs JamfCLIRunner more than once, each invocation exports response keys like `id` and `name` to the environment, overwriting values from the previous run. Use `output_vars` to rename exported keys to stable, unique names before the next processor runs.
+
+`output_vars` is a dictionary where:
+
+- **key** = the new environment variable name to set
+- **value** = the source key name from the JSON response
+
+```yaml
+Process:
+  # Step 1 — ensure the package category exists, capture its id
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: categories
+      action: apply
+      profile: "%PROFILE%"
+      confirm: "true"
+      data:
+        name: Utilities
+        priority: 9
+      output_vars:
+        pkg_category_id: id
+        pkg_category_name: name
+
+  # Step 2 — ensure the policy category exists, capture its id under a different name
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: categories
+      action: apply
+      profile: "%PROFILE%"
+      confirm: "true"
+      data:
+        name: Testing
+        priority: 9
+      output_vars:
+        policy_category_id: id
+        policy_category_name: name
+
+  # Step 3 — create the package record, referencing both captured IDs via a template
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: packages
+      action: apply
+      profile: "%PROFILE%"
+      confirm: "true"
+      from_file: JamfPro-Package.json
+```
+
+After step 1, `%pkg_category_id%` and `%pkg_category_name%` are set.
+After step 2, `%policy_category_id%` and `%policy_category_name%` are set, and `%id%`/`%name%` now reflect the policy category — but the package category values are safe in their renamed keys.
+
+The template file `JamfPro-Package.json` can then reference any of these:
+
+```json
+{
+  "packageName": "%pkg_name%",
+  "categoryId": "%pkg_category_id%"
+}
+```
+
+---
+
+### 7. `object_updated` and `StopProcessingIf`
+
+`apply` without `confirm: "true"` will not replace an object that already exists. jamf-cli exits with code 1 in that case, but the HTTP response is 200 — the object was found, just not modified. The processor treats this as a soft success rather than an error, and sets `object_updated` to `False`.
+
+This is useful in package-deployment recipes: if the package record already exists at the correct version there is no need to re-upload the binary or update the policy.
+
+```yaml
+Input:
+  REPLACE_PKG: "false"   # set to "true" to force replacement
+
+Process:
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: packages
+      action: apply
+      profile: "%PROFILE%"
+      confirm: "%REPLACE_PKG%"
+      verbose: "true"       # required for HTTP status detection
+      from_file: JamfPro-Package.json
+
+  # Stop here if nothing changed — no need to re-upload the pkg or update the policy
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: "object_updated == False"
+
+  # Only reached when the package record was newly created or updated
+  - Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+    Arguments:
+      type: pro
+      endpoint: packages
+      action: upload
+      profile: "%PROFILE%"
+      file: "%pkg_path%"
+```
+
+> **Note:** `verbose: "true"` must be set on the processor call that may exit with code 1. The HTTP status detection relies on jamf-cli's `--verbose` stderr output. Without it, any non-zero exit is treated as an error.
+
+---
+
+### 8. Jamf Protect
+
+The same processor handles Jamf Protect by changing `type` to `protect`.
+
+```yaml
+- Processor: com.github.grahampugh.recipes.JamfCLIRunner/JamfCLIRunner
+  Arguments:
+    type: protect
+    endpoint: plans
+    action: list
+    profile: "%PROTECT_PROFILE%"
+    all: true
+    output: json
+    out_file: "%RECIPE_CACHE_DIR%/plans.json"
+```
+
+---
+
+## YAML key naming caution
+
+PyYAML (used by AutoPkg) follows YAML 1.1, which treats a wide set of unquoted words as booleans — including `yes`, `no`, `true`, `false`, `on`, `off`, and their all-caps variants (`YES`, `NO`, `TRUE`, `FALSE`, `ON`, `OFF`). If any of these appear as unquoted keys in a recipe's `Input` or `Arguments` section they will be parsed as Python booleans, causing AutoPkg to fail with a `TypeError` when serialising the run results.
+
+**Avoid** using these words as input variable names. If you must, quote them:
+
+```yaml
+# Problematic — YES is a YAML 1.1 boolean key
+Input:
+  YES: "false"      # key parsed as True (bool), not "YES" (string)
+
+# Safe
+Input:
+  CONFIRM: "false"  # not a YAML boolean
+  "YES": "false"    # quoted — forces string key
+```
+
+The processor uses `confirm` (not `yes`) as its input key for the `--yes` flag precisely to avoid this issue.

--- a/JamfCLI-Templates/JamfPro-Package.json
+++ b/JamfCLI-Templates/JamfPro-Package.json
@@ -15,7 +15,8 @@
   "fillExistingUsers": false,
   "fillUserTemplate": false,
   "osInstall": false,
-  "osRequirements": "10.9"
+  "osRequirements": "10.9",
+  "rebootRequired": false
 }
 
 

--- a/JamfCLI-Templates/JamfPro-Package.json
+++ b/JamfCLI-Templates/JamfPro-Package.json
@@ -1,0 +1,21 @@
+{
+  "basePath": "%pkg_path%",
+  "categoryId": "%pkg_category_id%",
+  "fileName": "%pkg_name%",
+  "ignoreConflicts": false,
+  "info": "%pkg_info%",
+  "packageName": "%pkg_name%",
+  "priority": "%pkg_priority%",
+  "suppressEula": false,
+  "suppressFromDock": false,
+  "suppressRegistration": false,
+  "suppressUpdates": false,
+  "swu": false,
+  "notes": "%pkg_notes%",
+  "fillExistingUsers": false,
+  "fillUserTemplate": false,
+  "osInstall": false,
+  "osRequirements": "10.9"
+}
+
+

--- a/JamfCLI-Templates/JamfPro-Policy-InstallPackage.xml
+++ b/JamfCLI-Templates/JamfPro-Policy-InstallPackage.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<policy>
+	<general>
+		<name>%POLICY_NAME%</name>
+		<enabled>true</enabled>
+		<frequency>Ongoing</frequency>
+		<category>
+			<name>%POLICY_CATEGORY%</name>
+		</category>
+	</general>
+	<!-- scope handled by jamf-cli recipe -->
+	<package_configuration>
+		<packages>
+			<size>1</size>
+			<package>
+				<name>%pkg_name%</name>
+				<action>Install</action>
+			</package>
+		</packages>
+	</package_configuration>
+	<scripts>
+		<size>0</size>
+	</scripts>
+	<self_service>
+		<use_for_self_service>%USE_FOR_SELF_SERVICE%</use_for_self_service>
+		<install_button_text>%INSTALL_BUTTON_TEXT%</install_button_text>
+		<reinstall_button_text>%REINSTALL_BUTTON_TEXT%</reinstall_button_text>
+		<self_service_display_name>%SELF_SERVICE_DISPLAY_NAME%</self_service_display_name>
+		<self_service_description>%SELF_SERVICE_DESCRIPTION%</self_service_description>
+		<self_service_icon>
+			<filename>%SELF_SERVICE_ICON%</filename>
+			<uri>%icon_uri%</uri>
+		</self_service_icon>
+	</self_service>
+	<maintenance>
+		<recon>true</recon>
+	</maintenance>
+	<files_processes>
+		<run_command>%POLICY_RUN_COMMAND%</run_command>
+	</files_processes>
+</policy>

--- a/JamfCLI-Templates/JamfPro-Policy-InstallPackage.xml
+++ b/JamfCLI-Templates/JamfPro-Policy-InstallPackage.xml
@@ -5,7 +5,7 @@
 		<enabled>true</enabled>
 		<frequency>Ongoing</frequency>
 		<category>
-			<name>%POLICY_CATEGORY%</name>
+			<name>%policy_category_name%</name>
 		</category>
 	</general>
 	<!-- scope handled by jamf-cli recipe -->
@@ -28,8 +28,8 @@
 		<self_service_display_name>%SELF_SERVICE_DISPLAY_NAME%</self_service_display_name>
 		<self_service_description>%SELF_SERVICE_DESCRIPTION%</self_service_description>
 		<self_service_icon>
-			<filename>%SELF_SERVICE_ICON%</filename>
-			<uri>%icon_uri%</uri>
+			<filename>%app_icon_name%</filename>
+			<id>%app_icon_id%</id>
 		</self_service_icon>
 	</self_service>
 	<maintenance>

--- a/Jamf_Recipes/CarbonCopyCloner.jamf.recipe.yaml
+++ b/Jamf_Recipes/CarbonCopyCloner.jamf.recipe.yaml
@@ -1,0 +1,48 @@
+Comment: Recipe automatically generated from com.github.jss-recipes.jss.CarbonCopyCloner by JamfRecipeMaker
+Identifier: com.github.autopkg.grahampugh-recipes.jamf.CarbonCopyCloner
+ParentRecipe: com.github.keeleysam.recipes.pkg.CarbonCopyCloner
+MinimumVersion: "2.3"
+
+Input:
+  NAME: Carbon Copy Cloner
+  GROUP_NAME: Carbon Copy Cloner-update-smart
+  GROUP_TEMPLATE: JamfSmartGroupTemplate.xml
+  POLICY_NAME: "Install Latest %NAME%"
+  UPDATE_PREDICATE: pkg_uploaded == False
+  SELF_SERVICE_DESCRIPTION: Powerful disk cloning and backup utility.
+  CATEGORY: Utility
+  SELF_SERVICE_ICON: "%NAME%.png"
+  SELF_SERVICE_DISPLAY_NAME: "Install Latest %NAME%"
+  TESTING_GROUP_NAME: Testing
+  POLICY_TEMPLATE: JamfPolicyTemplate.xml
+  POLICY_CATEGORY: Testing
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfCategoryUploader
+    Arguments:
+      category_name: "%CATEGORY%"
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfCategoryUploader
+    Arguments:
+      category_name: "%POLICY_CATEGORY%"
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: "%CATEGORY%"
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: "%UPDATE_PREDICATE%"
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfComputerGroupUploader
+    Arguments:
+      replace_group: True
+      computergroup_name: "%GROUP_NAME%"
+      computergroup_template: "%GROUP_TEMPLATE%"
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPolicyUploader
+    Arguments:
+      policy_name: "%POLICY_NAME%"
+      icon: "%SELF_SERVICE_ICON%"
+      replace_policy: True
+      policy_template: "%POLICY_TEMPLATE%"


### PR DESCRIPTION
Introduce a set of example Jamf CLI recipes for managing policies, computers, and plans, along with example configurations and a README for guidance. This update also includes improvements and bug fixes to enhance functionality.